### PR TITLE
fix: fix tile worker coords

### DIFF
--- a/src/aws/osml/model_runner/tile_worker/tile_worker_utils.py
+++ b/src/aws/osml/model_runner/tile_worker/tile_worker_utils.py
@@ -153,7 +153,7 @@ def process_tiles(
                         metrics_logger=metrics,
                     ):
                         encoded_tile_data = gdal_tile_factory.create_encoded_tile(
-                            [tile_bounds[0][0], tile_bounds[0][1], tile_bounds[1][0], tile_bounds[1][1]]
+                            [tile_bounds[0][1], tile_bounds[0][0], tile_bounds[1][0], tile_bounds[1][1]]
                         )
 
                         with open(absolute_tile_path, "wb") as binary_file:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixing a bug where we were swapping coordinates incorrectly in ``tile_worker_utils.py``

*Testing:*
This has been deployed, integration tested, and run against the aircraft model to validate returns are as expected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
