### PR TITLE
fix: upate to toolkit-v1.1.1 and fix tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ python_requires = >=3.8
 include_package_data = True
 
 install_requires =
-    osml-imagery-toolkit>=1.0.0
+    osml-imagery-toolkit>=1.1.1
     numpy>=1.23.0
     shapely>=1.8.5,<2.0.0
     aws-embedded-metrics==3.1.0


### PR DESCRIPTION
This change pulls in the latest osml-imagery-toolkit release and updates some fragile unit tests that were impacted by the upgrade. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
