### PR TITLE
feat: support http model endpoints

### DIFF
--- a/src/aws/osml/model_runner/app.py
+++ b/src/aws/osml/model_runner/app.py
@@ -11,14 +11,6 @@ from secrets import token_hex
 from typing import Any, Dict, List, Optional, Tuple
 
 import shapely.geometry.base
-from aws.osml.gdal import (
-    GDALConfigEnv,
-    GDALDigitalElevationModelTileFactory,
-    get_image_extension,
-    load_gdal_dataset,
-    set_gdal_default_configuration,
-)
-from aws.osml.photogrammetry import DigitalElevationModel, ElevationModel, SensorModel, SRTMTileSet
 from aws_embedded_metrics.logger.metrics_logger import MetricsLogger
 from aws_embedded_metrics.metric_scope import metric_scope
 from aws_embedded_metrics.unit import Unit
@@ -28,8 +20,16 @@ from geojson import Feature
 from osgeo import gdal
 from osgeo.gdal import Dataset
 
-from .api import ImageRequest, InvalidImageRequestException, RegionRequest, SinkMode, \
-    VALID_MODEL_HOSTING_OPTIONS
+from aws.osml.gdal import (
+    GDALConfigEnv,
+    GDALDigitalElevationModelTileFactory,
+    get_image_extension,
+    load_gdal_dataset,
+    set_gdal_default_configuration,
+)
+from aws.osml.photogrammetry import DigitalElevationModel, ElevationModel, SensorModel, SRTMTileSet
+
+from .api import VALID_MODEL_HOSTING_OPTIONS, ImageRequest, InvalidImageRequestException, RegionRequest, SinkMode
 from .app_config import MetricLabels, ServiceConfig
 from .common import (
     EndpointUtils,

--- a/src/aws/osml/model_runner/inference/__init__.py
+++ b/src/aws/osml/model_runner/inference/__init__.py
@@ -5,6 +5,8 @@
 # flake8: noqa
 
 from .detector import Detector
+from .endpoint_factory import FeatureDetectorFactory
 from .feature_selection import FeatureSelector
 from .feature_utils import calculate_processing_bounds, get_source_property
-from .sm_endpoint_detector import SMDetector
+from .http_detector import HTTPDetector
+from .sm_detector import SMDetector

--- a/src/aws/osml/model_runner/inference/detector.py
+++ b/src/aws/osml/model_runner/inference/detector.py
@@ -15,8 +15,15 @@ class Detector(abc.ABC):
     The mechanism by which detected features are sent to their destination.
     """
 
-    def __init__(self) -> str:
-        return f"{self.mode.value}"
+    def __init__(self, endpoint: str) -> None:
+        """
+        Endpoint Detector base class.
+
+        :param endpoint: str = the endpoint that will be invoked
+        """
+        self.endpoint = endpoint
+        self.request_count = 0
+        self.error_count = 0
 
     @property
     @abc.abstractmethod

--- a/src/aws/osml/model_runner/inference/endpoint_builder.py
+++ b/src/aws/osml/model_runner/inference/endpoint_builder.py
@@ -1,0 +1,27 @@
+from abc import ABC, abstractmethod
+from typing import Optional
+
+from .detector import Detector
+
+
+class FeatureEndpointBuilder(ABC):
+    """
+    This is an abstract base for all classes to construct Detectors for various types of endpoints.
+    """
+
+    def __init__(self) -> None:
+        """
+        Constructor for the builder accepting required properties or formats for detectors
+
+        :return: None
+        """
+        pass
+
+    @abstractmethod
+    def build(self) -> Optional[Detector]:
+        """
+        Constructs the sensor model from the available information. Note that in cases where not enough information is
+        available to provide any solution, this method will return None.
+
+        :return: Optional[Detector] = the detector to generate features based on the provided build data
+        """

--- a/src/aws/osml/model_runner/inference/endpoint_factory.py
+++ b/src/aws/osml/model_runner/inference/endpoint_factory.py
@@ -1,0 +1,36 @@
+from typing import Dict, Optional
+
+from aws.osml.model_runner.api import ModelInvokeMode
+
+from .detector import Detector
+from .http_detector import HTTPDetectorBuilder
+from .sm_detector import SMDetectorBuilder
+
+
+class FeatureDetectorFactory:
+    def __init__(
+        self, endpoint: str, endpoint_mode: ModelInvokeMode, assumed_credentials: Optional[Dict[str, str]] = None
+    ) -> None:
+        """
+        :param endpoint: URL of the inference model endpoint
+        :param endpoint_mode: the type of endpoint (HTTP, SageMaker)
+        :param assumed_credentials: optional credentials to use with the model
+        """
+
+        self.endpoint = endpoint
+        self.endpoint_mode = endpoint_mode
+        self.assumed_credentials = assumed_credentials
+
+    def build(self) -> Optional[Detector]:
+        """
+        :return: a feature detector based on the parameters defined during initialization
+        """
+        if self.endpoint_mode == ModelInvokeMode.SM_ENDPOINT:
+            return SMDetectorBuilder(
+                endpoint=self.endpoint,
+                assumed_credentials=self.assumed_credentials,
+            ).build()
+        if self.endpoint_mode == ModelInvokeMode.HTTP_ENDPOINT:
+            return HTTPDetectorBuilder(
+                endpoint=self.endpoint,
+            ).build()

--- a/src/aws/osml/model_runner/inference/http_detector.py
+++ b/src/aws/osml/model_runner/inference/http_detector.py
@@ -9,6 +9,9 @@ from aws_embedded_metrics.logger.metrics_logger import MetricsLogger
 from aws_embedded_metrics.metric_scope import metric_scope
 from aws_embedded_metrics.unit import Unit
 from geojson import FeatureCollection
+from requests.exceptions import RetryError
+from urllib3.exceptions import MaxRetryError
+from urllib3.util.retry import Retry
 
 from aws.osml.model_runner.api import ModelInvokeMode
 from aws.osml.model_runner.app_config import MetricLabels, ServiceConfig
@@ -21,16 +24,74 @@ from .feature_utils import create_mock_feature_collection
 logger = logging.getLogger(__name__)
 
 
-class HTTPDetector(Detector):
-    def __init__(self, endpoint: str) -> None:
+class CountingRetry(urllib3.Retry):
+    def __init__(self, *args, **kwargs):
         """
-        A HTTP model endpoint invoking object, intended to query sagemaker endpoints.
-
-        :param endpoint: str = the full URL to invoke the model
+        Retry class implementation that counts the number of retries.
 
         :return: None
         """
-        self.http_pool = urllib3.PoolManager(cert_reqs="CERT_NONE")
+        super(CountingRetry, self).__init__(*args, **kwargs)
+        self.retry_counts = 0
+
+    def increment(self, *args, **kwargs) -> Retry:
+        # Call the parent's increment function
+        result = super(CountingRetry, self).increment(*args, **kwargs)
+        result.retry_counts = self.retry_counts + 1
+
+        return result
+
+    @classmethod
+    def from_retry(cls, retry_instance: Retry) -> "CountingRetry":
+        """Create a CountingRetry instance from a Retry instance."""
+        if isinstance(retry_instance, cls):
+            return retry_instance  # No conversion needed if it's already a CountingRetry instance
+
+        # Create a CountingRetry instance with the same configurations
+        return cls(
+            total=retry_instance.total,
+            connect=retry_instance.connect,
+            read=retry_instance.read,
+            redirect=retry_instance.redirect,
+            status=retry_instance.status,
+            other=retry_instance.other,
+            allowed_methods=retry_instance.allowed_methods,
+            status_forcelist=retry_instance.status_forcelist,
+            backoff_factor=retry_instance.backoff_factor,
+            raise_on_redirect=retry_instance.raise_on_redirect,
+            raise_on_status=retry_instance.raise_on_status,
+            history=retry_instance.history,
+            respect_retry_after_header=retry_instance.respect_retry_after_header,
+            remove_headers_on_redirect=retry_instance.remove_headers_on_redirect,
+        )
+
+
+class HTTPDetector(Detector):
+    def __init__(self, endpoint: str, name: Optional[str] = None, retry: Optional[urllib3.Retry] = None) -> None:
+        """
+        An HTTP model endpoint interface object, intended to query sagemaker endpoints.
+
+        :param endpoint: Full url to invoke the model
+        :param name: Name to give the model endpoint
+        :param retry: Retry policy to use when invoking the model
+
+        :return: None
+        """
+        # Setup Retry with exponential backoff
+        # - We will retry for a maximum of eight times.
+        # - We start with a backoff of 1 second.
+        # - We will double the backoff after each failed retry attempt.
+        # - We cap the maximum backoff time to 255 seconds.
+        # - We can adjust these values as required.
+        if retry is None:
+            self.retry = CountingRetry(total=8, backoff_factor=1, raise_on_status=True)
+        else:
+            self.retry = CountingRetry.from_retry(retry)
+        self.http_pool = urllib3.PoolManager(cert_reqs="CERT_NONE", retries=self.retry)
+        if name:
+            self.name = name
+        else:
+            self.name = "http"
         super().__init__(endpoint=endpoint)
 
     @property
@@ -42,17 +103,15 @@ class HTTPDetector(Detector):
         """
         Query the established endpoint mode to find features based on a payload
 
-        :param payload: BufferedReader = the BufferedReader object that holds the
-                                    data that will be sent to the feature generator
-        :param metrics: MetricsLogger = the metrics logger object to capture the log data on the system
+        :param payload: BufferedReader object that holds the data that will be sent to the feature generator
+        :param metrics: Metrics logger object to capture the log data on the system
 
-        :return: FeatureCollection = a feature collection containing the center point of a tile
+        :return: GeoJSON FeatureCollection containing the center point of a tile
         """
-        retry_count = 0
-        logger.info("Invoking HTTP Endpoint: {}".format(self.endpoint))
+        logger.info("Invoking Model: {}".format(self.name))
         if isinstance(metrics, MetricsLogger):
             metrics.set_dimensions()
-            metrics.put_dimensions({"HTTPModelEndpoint": self.endpoint})
+            metrics.put_dimensions({"ModelName": self.name})
 
         try:
             self.request_count += 1
@@ -74,10 +133,23 @@ class HTTPDetector(Detector):
                         url=self.endpoint,
                         body=payload,
                     )
-                    self.request_count = 1
+                    # get the history of retries and count them
+                    retry_count = self.retry.retry_counts
                     if isinstance(metrics, MetricsLogger):
                         metrics.put_metric(MetricLabels.ENDPOINT_RETRY_COUNT, retry_count, str(Unit.COUNT.value))
                     return geojson.loads(response.data.decode("utf-8"))
+        except RetryError as err:
+            self.error_count += 1
+            if isinstance(metrics, MetricsLogger):
+                metrics.put_metric(MetricLabels.MODEL_ERROR, 1, str(Unit.COUNT.value))
+            logger.error("Retry failed - failed due to {}".format(err))
+            logger.exception(err)
+        except MaxRetryError as err:
+            self.error_count += 1
+            if isinstance(metrics, MetricsLogger):
+                metrics.put_metric(MetricLabels.MODEL_ERROR, 1, str(Unit.COUNT.value))
+            logger.error("Max retries reached - failed due to {}".format(err.reason))
+            logger.exception(err)
         except JSONDecodeError as err:
             self.error_count += 1
             if isinstance(metrics, MetricsLogger):
@@ -89,7 +161,6 @@ class HTTPDetector(Detector):
                 )
             )
             logger.exception(err)
-            self.error_count += 1
 
         # Return an empty feature collection if the process errored out
         return FeatureCollection([])

--- a/src/aws/osml/model_runner/inference/http_detector.py
+++ b/src/aws/osml/model_runner/inference/http_detector.py
@@ -1,0 +1,109 @@
+import logging
+from io import BufferedReader
+from json import JSONDecodeError
+from typing import Optional
+
+import geojson
+import urllib3
+from aws_embedded_metrics.logger.metrics_logger import MetricsLogger
+from aws_embedded_metrics.metric_scope import metric_scope
+from aws_embedded_metrics.unit import Unit
+from geojson import FeatureCollection
+
+from aws.osml.model_runner.api import ModelInvokeMode
+from aws.osml.model_runner.app_config import MetricLabels, ServiceConfig
+from aws.osml.model_runner.common import Timer
+
+from .detector import Detector
+from .endpoint_builder import FeatureEndpointBuilder
+from .feature_utils import create_mock_feature_collection
+
+logger = logging.getLogger(__name__)
+
+
+class HTTPDetector(Detector):
+    def __init__(self, endpoint: str) -> None:
+        """
+        A HTTP model endpoint invoking object, intended to query sagemaker endpoints.
+
+        :param endpoint: str = the full URL to invoke the model
+
+        :return: None
+        """
+        self.http_pool = urllib3.PoolManager(cert_reqs="CERT_NONE")
+        super().__init__(endpoint=endpoint)
+
+    @property
+    def mode(self) -> ModelInvokeMode:
+        return ModelInvokeMode.HTTP_ENDPOINT
+
+    @metric_scope
+    def find_features(self, payload: BufferedReader, metrics: MetricsLogger) -> FeatureCollection:
+        """
+        Query the established endpoint mode to find features based on a payload
+
+        :param payload: BufferedReader = the BufferedReader object that holds the
+                                    data that will be sent to the feature generator
+        :param metrics: MetricsLogger = the metrics logger object to capture the log data on the system
+
+        :return: FeatureCollection = a feature collection containing the center point of a tile
+        """
+        retry_count = 0
+        logger.info("Invoking HTTP Endpoint: {}".format(self.endpoint))
+        if isinstance(metrics, MetricsLogger):
+            metrics.set_dimensions()
+            metrics.put_dimensions({"HTTPModelEndpoint": self.endpoint})
+
+        try:
+            self.request_count += 1
+            if isinstance(metrics, MetricsLogger):
+                metrics.put_metric(MetricLabels.MODEL_INVOCATION, 1, str(Unit.COUNT.value))
+
+            with Timer(
+                task_str="Invoke HTTP Endpoint",
+                metric_name=MetricLabels.ENDPOINT_LATENCY,
+                logger=logger,
+                metrics_logger=metrics,
+            ):
+                # If we are not running against a real model
+                if self.endpoint == ServiceConfig.noop_model_name:
+                    return create_mock_feature_collection(payload)
+                else:
+                    response = self.http_pool.request(
+                        method="POST",
+                        url=self.endpoint,
+                        body=payload,
+                    )
+                    self.request_count = 1
+                    if isinstance(metrics, MetricsLogger):
+                        metrics.put_metric(MetricLabels.ENDPOINT_RETRY_COUNT, retry_count, str(Unit.COUNT.value))
+                    return geojson.loads(response.data.decode("utf-8"))
+        except JSONDecodeError as err:
+            self.error_count += 1
+            if isinstance(metrics, MetricsLogger):
+                metrics.put_metric(MetricLabels.FEATURE_DECODE, 1, str(Unit.COUNT.value))
+                metrics.put_metric(MetricLabels.MODEL_ERROR, 1, str(Unit.COUNT.value))
+            logger.error(
+                "Unable to decode response from model. URL: {}, Status: {}, Headers: {}, Response: {}".format(
+                    self.endpoint, response.status, response.info(), response.data
+                )
+            )
+            logger.exception(err)
+            self.error_count += 1
+
+        # Return an empty feature collection if the process errored out
+        return FeatureCollection([])
+
+
+class HTTPDetectorBuilder(FeatureEndpointBuilder):
+    def __init__(
+        self,
+        endpoint: str,
+    ):
+        super().__init__()
+        self.endpoint = endpoint
+
+    def build(self) -> Optional[Detector]:
+        return HTTPDetector(
+            endpoint=self.endpoint,
+        )

--- a/src/aws/osml/model_runner/inference/sm_detector.py
+++ b/src/aws/osml/model_runner/inference/sm_detector.py
@@ -1,9 +1,11 @@
 #  Copyright 2023 Amazon.com, Inc. or its affiliates.
 
+#  Copyright 2023 Amazon.com, Inc. or its affiliates.
+
 import logging
 from io import BufferedReader
 from json import JSONDecodeError
-from typing import Dict
+from typing import Dict, Optional
 
 import boto3
 import geojson
@@ -18,22 +20,22 @@ from aws.osml.model_runner.app_config import BotoConfig, MetricLabels, ServiceCo
 from aws.osml.model_runner.common import Timer
 
 from .detector import Detector
+from .endpoint_builder import FeatureEndpointBuilder
 from .feature_utils import create_mock_feature_collection
 
 logger = logging.getLogger(__name__)
 
 
 class SMDetector(Detector):
-    def __init__(self, model_name: str, assumed_credentials: Dict[str, str] = None) -> None:
+    def __init__(self, endpoint: str, assumed_credentials: Dict[str, str] = None) -> None:
         """
         A sagemaker model endpoint invoking object, intended to query sagemaker endpoints.
 
-        :param model_name: str = the name of the sagemaker endpoint that will be invoked
+        :param endpoint: str = the name of the sagemaker endpoint that will be invoked
         :param assumed_credentials: Dict[str, str] = Optional credentials to invoke the sagemaker model
 
         :return: None
         """
-        super().__init__()
         if assumed_credentials is not None:
             # Here we will be invoking the SageMaker endpoints using an IAM role other than the
             # one for this process. Use those credentials when creating the Boto3 SageMaker client.
@@ -47,13 +49,11 @@ class SMDetector(Detector):
                 aws_session_token=assumed_credentials.get("SessionToken"),
             )
         else:
-            # If no invocation role is provided the assumption is that the default role for this
+            # If no invocation role is provided, the assumption is that the default role for this
             # container will be sufficient to invoke the SageMaker endpoints. This will typically
             # be the case for AWS managed models running in the same account as the model runner.
             self.sm_client = boto3.client("sagemaker-runtime", config=BotoConfig.sagemaker)
-        self.model_name = model_name
-        self.request_count = 0
-        self.error_count = 0
+        super().__init__(endpoint=endpoint)
 
     @property
     def mode(self) -> ModelInvokeMode:
@@ -65,15 +65,15 @@ class SMDetector(Detector):
         Query the established endpoint mode to find features based on a payload
 
         :param payload: BufferedReader = the BufferedReader object that holds the
-                                    data that will be  sent to the feature generator
+                                    data that will be sent to the feature generator
         :param metrics: MetricsLogger = the metrics logger object to capture the log data on the system
 
         :return: FeatureCollection = a feature collection containing the center point of a tile
         """
-        logger.info("Invoking Model: {}".format(self.model_name))
+        logger.info("Invoking Model: {}".format(self.endpoint))
         if isinstance(metrics, MetricsLogger):
             metrics.set_dimensions()
-            metrics.put_dimensions({"ModelName": self.model_name})
+            metrics.put_dimensions({"ModelName": self.endpoint})
 
         try:
             self.request_count += 1
@@ -87,13 +87,13 @@ class SMDetector(Detector):
                 metrics_logger=metrics,
             ):
                 # If we are not running against a real model
-                if self.model_name == ServiceConfig.noop_model_name:
+                if self.endpoint == ServiceConfig.noop_model_name:
                     # We are expecting the body of the message to contain a geojson FeatureCollection
                     return create_mock_feature_collection(payload)
                 else:
                     # Use the sagemaker model endpoint to invoke the model and return detection points
                     # as a geojson FeatureCollection
-                    model_response = self.sm_client.invoke_endpoint(EndpointName=self.model_name, Body=payload)
+                    model_response = self.sm_client.invoke_endpoint(EndpointName=self.endpoint, Body=payload)
                     retry_count = model_response.get("ResponseMetadata", {}).get("RetryAttempts", 0)
                     if isinstance(metrics, MetricsLogger):
                         metrics.put_metric(MetricLabels.ENDPOINT_RETRY_COUNT, retry_count, str(Unit.COUNT.value))
@@ -124,3 +124,23 @@ class SMDetector(Detector):
 
         # Return an empty feature collection if the process errored out
         return FeatureCollection([])
+
+
+class SMDetectorBuilder(FeatureEndpointBuilder):
+    def __init__(self, endpoint: str, assumed_credentials: Dict[str, str] = None):
+        """
+        :param endpoint: The URL to the SageMaker endpoint
+        :param assumed_credentials: The credentials to use with the SageMaker endpoint
+        """
+        super().__init__()
+        self.endpoint = endpoint
+        self.assumed_credentials = assumed_credentials
+
+    def build(self) -> Optional[Detector]:
+        """
+        :return: a SageMaker detector based on the parameters defined during initialization
+        """
+        return SMDetector(
+            endpoint=self.endpoint,
+            assumed_credentials=self.assumed_credentials,
+        )

--- a/src/aws/osml/model_runner/tile_worker/tile_worker.py
+++ b/src/aws/osml/model_runner/tile_worker/tile_worker.py
@@ -40,6 +40,11 @@ class TileWorker(Thread):
 
             if image_info is None:
                 logging.info("All images processed. Stopping tile worker.")
+                logging.info(
+                    "Feature Detector Stats: {} requests with {} errors".format(
+                        self.feature_detector.request_count, self.feature_detector.error_count
+                    )
+                )
                 break
 
             try:

--- a/src/aws/osml/model_runner/tile_worker/tile_worker.py
+++ b/src/aws/osml/model_runner/tile_worker/tile_worker.py
@@ -12,7 +12,7 @@ from aws_embedded_metrics.unit import Unit
 
 from aws.osml.model_runner.app_config import MetricLabels
 from aws.osml.model_runner.database import FeatureTable
-from aws.osml.model_runner.inference import SMDetector
+from aws.osml.model_runner.inference import Detector
 from aws.osml.model_runner.tile_worker import FeatureRefinery
 
 
@@ -20,7 +20,7 @@ class TileWorker(Thread):
     def __init__(
         self,
         in_queue: Queue,
-        feature_detector: SMDetector,
+        feature_detector: Detector,
         feature_refinery: Optional[FeatureRefinery],
         feature_table: FeatureTable,
         metrics: MetricsLogger,
@@ -40,15 +40,10 @@ class TileWorker(Thread):
 
             if image_info is None:
                 logging.info("All images processed. Stopping tile worker.")
-                logging.info(
-                    "Feature Detector Stats: {} requests with {} errors".format(
-                        self.feature_detector.request_count, self.feature_detector.error_count
-                    )
-                )
                 break
 
             try:
-                logging.info("Invoking SM Endpoint")
+                logging.info("Invoking Feature Detector Endpoint")
                 with open(image_info["image_path"], mode="rb") as payload:
                     feature_collection = self.feature_detector.find_features(payload)
 

--- a/src/aws/osml/model_runner/tile_worker/tile_worker_utils.py
+++ b/src/aws/osml/model_runner/tile_worker/tile_worker_utils.py
@@ -17,10 +17,10 @@ from aws.osml.model_runner.api import RegionRequest
 from aws.osml.model_runner.app_config import MetricLabels, ServiceConfig
 from aws.osml.model_runner.common import ImageDimensions, ImageRegion, Timer, get_credentials_for_assumed_role
 from aws.osml.model_runner.database import FeatureTable
-from aws.osml.model_runner.inference import SMDetector
 from aws.osml.model_runner.tile_worker import FeatureRefinery, TileWorker
 from aws.osml.photogrammetry import ElevationModel, SensorModel
 
+from ..inference.endpoint_factory import FeatureDetectorFactory
 from .exceptions import ProcessTilesException, SetupTileWorkersException
 
 logger = logging.getLogger(__name__)
@@ -61,7 +61,11 @@ def setup_tile_workers(
 
             # Ignoring mypy error - if model_name was None the call to validate the region
             # request at the start of this function would have failed
-            feature_detector = SMDetector(region_request.model_name, model_invocation_credentials)  # type: ignore[arg-type]
+            feature_detector = FeatureDetectorFactory(
+                endpoint=region_request.model_name,
+                endpoint_mode=region_request.model_invoke_mode,
+                assumed_credentials=model_invocation_credentials,
+            ).build()
 
             feature_refinery = None
             if sensor_model is not None:

--- a/test/aws/osml/model_runner/inference/test_feature_detector_factory.py
+++ b/test/aws/osml/model_runner/inference/test_feature_detector_factory.py
@@ -1,0 +1,25 @@
+import unittest
+
+
+class TestFeatureDetectorFactory(unittest.TestCase):
+    def test_sm_detector_generation(self):
+        from aws.osml.model_runner.api.inference import ModelInvokeMode
+        from aws.osml.model_runner.inference import FeatureDetectorFactory, SMDetector
+
+        feature_detector = FeatureDetectorFactory(
+            endpoint="test",
+            endpoint_mode=ModelInvokeMode.SM_ENDPOINT,
+        ).build()
+        assert isinstance(feature_detector, SMDetector)
+        assert feature_detector.mode == ModelInvokeMode.SM_ENDPOINT
+
+    def test_http_detector_generation(self):
+        from aws.osml.model_runner.api.inference import ModelInvokeMode
+        from aws.osml.model_runner.inference import FeatureDetectorFactory, HTTPDetector
+
+        feature_detector = FeatureDetectorFactory(
+            endpoint="test",
+            endpoint_mode=ModelInvokeMode.HTTP_ENDPOINT,
+        ).build()
+        assert isinstance(feature_detector, HTTPDetector)
+        assert feature_detector.mode == ModelInvokeMode.HTTP_ENDPOINT

--- a/test/aws/osml/model_runner/inference/test_sm_detector.py
+++ b/test/aws/osml/model_runner/inference/test_sm_detector.py
@@ -49,7 +49,7 @@ class TestSMDetector(unittest.TestCase):
             "SessionToken": "FAKE-SESSION-TOKEN",
             "Expiration": datetime.datetime.now(),
         }
-        with mock.patch("aws.osml.model_runner.inference.sm_endpoint_detector.boto3") as mock_boto3:
+        with mock.patch("aws.osml.model_runner.inference.sm_detector.boto3") as mock_boto3:
             mock_boto3.client.return_value = sm_client
             SMDetector("test-endpoint", aws_credentials)
             mock_boto3.client.assert_called_once_with(
@@ -128,7 +128,14 @@ class TestSMDetector(unittest.TestCase):
 
     def test_sm_name_generation(self):
         from aws.osml.model_runner.api.inference import ModelInvokeMode
-        from aws.osml.model_runner.inference import SMDetector
+        from aws.osml.model_runner.inference import HTTPDetector, SMDetector
 
-        feature_detector = SMDetector("test-endpoint")
-        assert feature_detector.mode == ModelInvokeMode.SM_ENDPOINT
+        sm_name = "sm-test"
+        sm_detector = SMDetector(endpoint=sm_name)
+        assert sm_detector.mode == ModelInvokeMode.SM_ENDPOINT
+        assert sm_detector.endpoint == sm_name
+
+        http_name = "http-test"
+        http_detector = HTTPDetector(endpoint=http_name)
+        assert http_detector.mode == ModelInvokeMode.HTTP_ENDPOINT
+        assert http_detector.endpoint == http_name

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -339,7 +339,7 @@ class TestModelRunner(unittest.TestCase):
     # Remember that with multiple patch decorators the order of the mocks in the parameter list is
     # reversed (i.e. the first mock parameter is the last decorator defined). Also note that the
     # pytest fixtures must come at the end.
-    @mock.patch("aws.osml.model_runner.tile_worker.tile_worker_utils.SMDetector", autospec=True)
+    @mock.patch("aws.osml.model_runner.tile_worker.tile_worker_utils.FeatureDetectorFactory", autospec=True)
     @mock.patch("aws.osml.model_runner.tile_worker.tile_worker_utils.FeatureTable", autospec=True)
     @mock.patch("aws.osml.model_runner.tile_worker.tile_worker_utils.TileWorker", autospec=True)
     @mock.patch("aws.osml.model_runner.tile_worker.tile_worker_utils.Queue", autospec=True)
@@ -471,7 +471,7 @@ class TestModelRunner(unittest.TestCase):
         elevation_model = ModelRunner.create_elevation_model()
         assert not elevation_model
 
-    @mock.patch("aws.osml.model_runner.tile_worker.tile_worker_utils.SMDetector", autospec=True)
+    @mock.patch("aws.osml.model_runner.tile_worker.tile_worker_utils.FeatureDetectorFactory", autospec=True)
     @mock.patch("aws.osml.model_runner.tile_worker.tile_worker_utils.FeatureTable", autospec=True)
     @mock.patch("aws.osml.model_runner.tile_worker.tile_worker_utils.TileWorker", autospec=True)
     @mock.patch("aws.osml.model_runner.tile_worker.tile_worker_utils.Queue", autospec=True)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Added support for model runner to to send inference requests to HTTP endpoints in addition to SageMaker endpoints. Implemented unit test for new classes and updated logic. 

*Testing:*
* Successfully ran tox unit tests 
* Deployed changes with the latest guidance baseline and confirmed integration tests are functional
* Ran various images through the aircraft model to ensure behavior is expected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
