### PR TITLE
Update Github action workflows

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -7,9 +7,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         lfs: 'true'
-        ssh-key: ${{ secrets.git_ssh_key }}
     - name: Build the Docker image
       run: docker build . --file Dockerfile --tag osml-model-runner:$(date +%s)

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,17 +1,11 @@
 name: Build Docker Container
 
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+  workflow_call:
 
 jobs:
-
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/docker-publish-dockerhub.yml
+++ b/.github/workflows/docker-publish-dockerhub.yml
@@ -1,16 +1,11 @@
 name: Publish OSML Model Runner DockerHub Container
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
 
-# GitHub recommends pinning actions to a commit SHA.
-# To get a newer version, you will need to update the SHA.
-# You can also reference a tag or branch, but the action may change without warning.
-
-# Configures this workflow to run every time a change is pushed to the branch called `main`.
 on:
   workflow_call:
+
+env:
+  REGISTRY: awsosml
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   push_to_registry:
@@ -18,10 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           lfs: 'true'
-          ssh-key: ${{ secrets.git_ssh_key }}
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -31,7 +25,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: awsosml/osml-model-runner
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       - name: Publish Container to Dockerhub
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/docker-publish-dockerhub.yml
+++ b/.github/workflows/docker-publish-dockerhub.yml
@@ -1,4 +1,4 @@
-name: Publish DockerHub Container
+name: Publish OSML Model Runner DockerHub Container
 # This workflow uses actions that are not certified by GitHub.
 # They are provided by a third-party and are governed by
 # separate terms of service, privacy policy, and support
@@ -10,8 +10,7 @@ name: Publish DockerHub Container
 
 # Configures this workflow to run every time a change is pushed to the branch called `main`.
 on:
-  push:
-    branches: ['main']
+  workflow_call:
 
 jobs:
   push_to_registry:
@@ -23,21 +22,18 @@ jobs:
         with:
           lfs: 'true'
           ssh-key: ${{ secrets.git_ssh_key }}
-
       - name: Log in to Docker Hub
-        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        uses: docker/metadata-action@v5
         with:
           images: awsosml/osml-model-runner
-
       - name: Publish Container to Dockerhub
-        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/docker-publish-github.yml
+++ b/.github/workflows/docker-publish-github.yml
@@ -1,16 +1,13 @@
-name: Publish GitHub Container
+name: Publish OSML Model Runner GitHub Container
 
-# Configures this workflow to run every time a change is pushed to the branch called `main`.
 on:
-  push:
-    branches: ['main']
+  workflow_call:
 
 # Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
-# There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
@@ -18,13 +15,12 @@ jobs:
     permissions:
       contents: read
       packages: write
-      #
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
       # Uses the `docker/login-action` action to log in to the Container registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
       - name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -32,14 +28,14 @@ jobs:
       # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
       # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
       # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
       - name: Push to Github
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        uses: docker/build-push-action@v5
         with:
           context: .
           push: true

--- a/.github/workflows/docker-publish-github.yml
+++ b/.github/workflows/docker-publish-github.yml
@@ -3,7 +3,6 @@ name: Publish OSML Model Runner GitHub Container
 on:
   workflow_call:
 
-# Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
@@ -11,29 +10,25 @@ env:
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
-    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
     permissions:
       contents: read
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
-      # Uses the `docker/login-action` action to log in to the Container registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+        uses: actions/checkout@v4
+        with:
+          lfs: 'true'
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
-      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
-      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
       - name: Push to Github
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/documentation-publish.yml
+++ b/.github/workflows/documentation-publish.yml
@@ -8,9 +8,10 @@ permissions:
 
 jobs:
   docs:
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v3
       - name: Install dependencies
         run: |
@@ -23,7 +24,6 @@ jobs:
           tox -e docs
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3.9.3
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         with:
           publish_branch: gh-pages
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/documentation-publish.yml
+++ b/.github/workflows/documentation-publish.yml
@@ -1,7 +1,11 @@
-name: Docs
-on: [push, pull_request, workflow_dispatch]
+name: Generate and Publish Documentation for OSML Model Runner
+
+on:
+  workflow_call:
+
 permissions:
     contents: write
+
 jobs:
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/osml-model-runner-build.yml
+++ b/.github/workflows/osml-model-runner-build.yml
@@ -1,0 +1,13 @@
+name: "OSML Model Runner Build Workflow"
+
+on:
+  pull_request:
+    branches: ["main", "dev"]
+
+jobs:
+  Build_Validate_Tox:
+    uses: ./.github/workflows/python-tox.yml
+    secrets: inherit
+  Build_Docker_Container:
+    uses: ./.github/workflows/docker-build.yml
+    secrets: inherit

--- a/.github/workflows/osml-model-runner-publish.yml
+++ b/.github/workflows/osml-model-runner-publish.yml
@@ -1,0 +1,29 @@
+name: "OSML Model Runner Build and Publish Workflow"
+
+on:
+  push:
+    branches: ["main", "dev"]
+
+jobs:
+  Build_Validate_Tox:
+    uses: ./.github/workflows/python-tox.yml
+    secrets: inherit
+  Build_Docker_Container:
+    uses: ./.github/workflows/docker-build.yml
+    secrets: inherit
+  Publish_Python:
+    needs: [Build_Validate_Tox, Build_Docker_Container]
+    uses: ./.github/workflows/python-publish.yml
+    secrets: inherit
+  Publish_Docker_Github:
+    needs: [Build_Validate_Tox, Build_Docker_Container]
+    uses: ./.github/workflows/docker-publish-dockerhub.yml
+    secrets: inherit
+  Publish_Docker_Dockerhub:
+    needs: [Build_Validate_Tox, Build_Docker_Container]
+    uses: ./.github/workflows/docker-publish-github.yml
+    secrets: inherit
+  Publish_Documentation:
+    needs: [Publish_Python, Publish_Docker_Github, Publish_Docker_Dockerhub]
+    uses: ./.github/workflows/documentation-publish.yml
+    secrets: inherit

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,11 +1,6 @@
 # This workflow will upload a Python Package using Twine when a release is created
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
 
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
 name: Publish Python Package
 
 on:
@@ -21,7 +16,7 @@ jobs:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
       uses: actions/setup-python@v3
       with:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -9,6 +9,7 @@
 name: Publish Python Package
 
 on:
+  workflow_call:
   release:
     types: [published]
 
@@ -17,9 +18,8 @@ permissions:
 
 jobs:
   deploy:
-
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
@@ -33,7 +33,8 @@ jobs:
     - name: Build package
       run: python -m build
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      uses: pypa/gh-action-pypi-publish@v5
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -33,8 +33,7 @@ jobs:
     - name: Build package
       run: python -m build
     - name: Publish package
-      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-      uses: pypa/gh-action-pypi-publish@v5
+      uses: pypa/gh-action-pypi-publish@v1.8.10
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/python-tox.yml
+++ b/.github/workflows/python-tox.yml
@@ -4,19 +4,14 @@
 name: Build/Validation with Tox
 
 on:
-  push:
-    branches: [ "main", "dev" ]
-  pull_request:
-    branches: [ "main", "dev" ]
+  workflow_call
 
 permissions:
   contents: read
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/python-tox.yml
+++ b/.github/workflows/python-tox.yml
@@ -1,10 +1,7 @@
-# This workflow will install Python dependencies, run tests and lint with a single version of Python
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
-
 name: Build/Validation with Tox
 
 on:
-  workflow_call
+  workflow_call:
 
 permissions:
   contents: read
@@ -13,10 +10,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         lfs: 'true'
-        ssh-key: ${{ secrets.git_ssh_key }}
     - name: Set up Python 3.10
       uses: actions/setup-python@v3
       with:


### PR DESCRIPTION
**Description of changes:**
- Restructure the workflows. There are 2 workflows:
  - osml-model-runner-build 
     - This workflow will be executed only IF the pull request have been made to `dev` or `main` branch. 
  - osml-model-runner-publish
     - This workflow will be executed only IF the changes have been merged into `dev` or `main` branch. This will publish docker container to respective repository (github or dockerhub) and if its on `main` branch, it will published an update to pypi and push documentation pages to `gh-pages` branch
- Eliminate all commits id for github actions and used stable version of it


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
