### PR TITLE
Update the dockerhub name

### DIFF
--- a/.github/workflows/docker-publish-dockerhub.yml
+++ b/.github/workflows/docker-publish-dockerhub.yml
@@ -5,7 +5,7 @@ on:
 
 env:
   REGISTRY: awsosml
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: ${{ github.event.repository.name }}
 
 jobs:
   push_to_registry:

--- a/.github/workflows/osml-model-runner-publish.yml
+++ b/.github/workflows/osml-model-runner-publish.yml
@@ -15,11 +15,11 @@ jobs:
     needs: [Build_Validate_Tox, Build_Docker_Container]
     uses: ./.github/workflows/python-publish.yml
     secrets: inherit
-  Publish_Docker_Github:
+  Publish_Docker_Dockerhub:
     needs: [Build_Validate_Tox, Build_Docker_Container]
     uses: ./.github/workflows/docker-publish-dockerhub.yml
     secrets: inherit
-  Publish_Docker_Dockerhub:
+  Publish_Docker_Github:
     needs: [Build_Validate_Tox, Build_Docker_Container]
     uses: ./.github/workflows/docker-publish-github.yml
     secrets: inherit


### PR DESCRIPTION
**Description of changes:**
- Latest github action failed due to the incorrect dockerhub name. It was fetching the entire repo name (org/repo-name) rather than partial repo name (repo-name). 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
