### PR TITLE
fix: fixing http detector bug

### DIFF
--- a/src/aws/osml/model_runner/inference/http_detector.py
+++ b/src/aws/osml/model_runner/inference/http_detector.py
@@ -125,7 +125,9 @@ class HTTPDetector(Detector):
                 metrics_logger=metrics,
             ):
                 # If we are not running against a real model
-                if self.endpoint == ServiceConfig.noop_model_name:
+                if self.endpoint == ServiceConfig.noop_geom_model_name:
+                    return create_mock_feature_collection(payload, geom=True)
+                elif self.endpoint == ServiceConfig.noop_bounds_model_name:
                     return create_mock_feature_collection(payload)
                 else:
                     response = self.http_pool.request(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixing a bug that causes the HTTP model endpoint calls to crash due to a property for the NOOP model not existing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
