### PR TITLE
fix: Update osml-imagery-toolkit and shapely version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,9 +39,9 @@ python_requires = >=3.8
 include_package_data = True
 
 install_requires =
-    osml-imagery-toolkit>=1.1.1
+    osml-imagery-toolkit>=1.2.0
     numpy>=1.23.0
-    shapely>=1.8.5,<2.0.0
+    shapely>=1.8.5
     aws-embedded-metrics==3.1.0
     boto3==1.28.1
     botocore==1.31.1


### PR DESCRIPTION
*Issue #, if available:*

**Description of changes:**
- Update `osml-imagery-toolkit` to v1.2.0
- Update `shapely` version to be greater than 1.8.5 since `osml-imagery-toolkit` set the `shapely` version to 2.0.2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
