### PR TITLE
fix: optimize container size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,13 +1,12 @@
 *~
 *#
 *.swp
-**/*.iml
+**/*Dockerfile
 **/*.DS_Store
 **/*.tox
 **/*.idea
 **/*venv
 **/__pycache__/
-**/*.py[cod]
 **/*$py.class
 **/*.egg-info/
 **/.coverage
@@ -17,5 +16,4 @@
 **/.mypy_cache
 **/doc/_apidoc/
 **/build
-**/dist
 **/htmlcov

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,48 +1,64 @@
-FROM public.ecr.aws/amazonlinux/amazonlinux:2023 as model_runner
+# Stage 1: Build environment
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023-minimal as build
 
-# only override if you're using a mirror with a cert pulled in using cert-base as a build parameter
+# Set up build arguments and environment variables
 ARG BUILD_CERT=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 ARG PIP_INSTALL_LOCATION=https://pypi.org/simple/
-
-# give sudo permissions
-USER root
-
-# set working directory to home
-WORKDIR /home
-
-# configure, update, and refresh yum enviornment
-RUN yum update -y && yum clean all && yum makecache && yum install -y wget shadow-utils
-
-# install miniconda
 ARG MINICONDA_VERSION=Miniconda3-latest-Linux-x86_64
 ARG MINICONDA_URL=https://repo.anaconda.com/miniconda/${MINICONDA_VERSION}.sh
-RUN wget -c ${MINICONDA_URL} \
-    && chmod +x ${MINICONDA_VERSION}.sh \
-    && ./${MINICONDA_VERSION}.sh -b -f -p /opt/conda \
-    && rm ${MINICONDA_VERSION}.sh \
-    && ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh
-
-# add conda to the path so we can execute it by name
 ENV PATH=/opt/conda/bin:$PATH
-
-# set all the ENV vars needed for build
 ENV CONDA_TARGET_ENV=osml_model_runner
-ENV CC="clang"
-ENV CXX="clang++"
-ENV ARCHFLAGS="-arch x86_64"
-ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/opt/conda/lib/:/opt/conda/bin:/usr/include:/usr/local/"
-ENV PROJ_LIB=/opt/conda/share/proj
 
-# copy our conda env configuration for Python 3.10
+# Set working directory
+WORKDIR /home
+
+# Install necessary packages
+USER root
+RUN dnf update -y && dnf install -y wget shadow-utils gcc && dnf clean all
+
+# Install Miniconda
+RUN wget -c ${MINICONDA_URL} && \
+    chmod +x ${MINICONDA_VERSION}.sh && \
+    ./${MINICONDA_VERSION}.sh -b -f -p /opt/conda && \
+    rm ${MINICONDA_VERSION}.sh && \
+    ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh
+
+# Copy the conda environment file
 COPY environment-py310.yml environment.yml
 
-# create the conda env
-RUN conda env create
+# Create the conda environment and remove additional unnecessary files
+RUN conda env create -f environment.yml \
+     && conda clean -afy \
+     && find /opt/conda/ -follow -type f -name '*.a' -delete \
+     && find /opt/conda/ -follow -type f -name '*.pyc' -delete \
+     && find /opt/conda/ -follow -type f -name '*.js.map' -delete
 
-# create /entry.sh which will be our new shell entry point
-# this performs actions to configure the environment
-# before starting a new shell (which inherits the env).
-# the exec is important as this allows signals to passpw
+# Copy the application source code
+COPY . osml-model-runner
+
+# Install the model runner application
+RUN . /opt/conda/etc/profile.d/conda.sh && \
+    conda activate ${CONDA_TARGET_ENV} && \
+    python3 -m pip install osml-model-runner/.
+
+# Stage 2: Runtime environment
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023-minimal as model_runner
+
+# Set up runtime environment variables
+ENV CONDA_TARGET_ENV=osml_model_runner
+ENV PATH=/opt/conda/bin:$PATH
+
+# Set working directory
+WORKDIR /home
+
+# Copy the conda environment from the build stage
+COPY --from=build /opt/conda /opt/conda
+RUN ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh
+
+# Copy the application from the build stage
+COPY --from=build /home/osml-model-runner /home/osml-model-runner
+
+# Create entrypoint script
 RUN     (echo '#!/bin/bash' \
     &&   echo '__conda_setup="$(/opt/conda/bin/conda shell.bash hook 2> /dev/null)"' \
     &&   echo 'eval "$__conda_setup"' \
@@ -51,29 +67,12 @@ RUN     (echo '#!/bin/bash' \
     &&   echo 'exec "$@"'\
         ) >> /entry.sh && chmod +x /entry.sh
 
-# tell the docker build process to use this for RUN.
-# the default shell on Linux is ["/bin/sh", "-c"], and on Windows is ["cmd", "/S", "/C"]
-SHELL ["/entry.sh", "/bin/bash", "-c"]
+# Configure user and permissions
+RUN dnf install -y shadow-utils
+RUN adduser modelrunner && \
+    chown -R modelrunner:modelrunner ./
 
-# configure .bashrc to drop into a conda env and immediately activate our TARGET env
-RUN conda init && echo 'conda activate "${CONDA_TARGET_ENV:-base}"' >>  ~/.bashrc
-
-# copy our lcoal application source into the container
-COPY . osml-model-runner
-
-# install the model runner application from source
-RUN python3 -m pip install osml-model-runner/.
-
-# clean up the conda install
-RUN conda clean -afy
-
-# set up a health check at that port
-HEALTHCHECK NONE
-
-# set up a user to run the container as and assume it
-RUN adduser modelrunner
-RUN chown -R modelrunner:modelrunner ./
 USER modelrunner
 
-# set the entry point script
+# Set entry point
 ENTRYPOINT ["/entry.sh", "/bin/bash", "-c", "python3 osml-model-runner/bin/oversightml-mr-entry-point.py"]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updating the container build process to be more optimal and produce a smaller base image for the model runner package using several techniques found in:

* https://jcristharif.com/conda-docker-tips.html
* https://docs.docker.com/build/building/multi-stage/

This takes the base image produces from the docker build from 3.5GB to 1.86GB in size.

*Testing:*
Deployed and tested changes in my dev account. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
