### PR TITLE
fix: updating extents calculation

### DIFF
--- a/.github/workflows/python-tox.yml
+++ b/.github/workflows/python-tox.yml
@@ -13,10 +13,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         lfs: 'true'
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v3
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: "3.11"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip tox

--- a/test/aws/osml/model_runner/database/test_ddb_helper.py
+++ b/test/aws/osml/model_runner/database/test_ddb_helper.py
@@ -4,14 +4,14 @@ from unittest import TestCase
 
 import boto3
 from botocore.exceptions import ClientError
-from moto import mock_dynamodb
+from moto import mock_aws
 
 TEST_JOB_TABLE_KEY_SCHEMA = [{"AttributeName": "image_id", "KeyType": "HASH"}]
 TEST_JOB_TABLE_ATTRIBUTE_DEFINITIONS = [{"AttributeName": "image_id", "AttributeType": "S"}]
 TEST_IMAGE_ID = "test-image-id"
 
 
-@mock_dynamodb
+@mock_aws
 class TestDDBHelper(TestCase):
     def setUp(self):
         from aws.osml.model_runner.app_config import BotoConfig

--- a/test/aws/osml/model_runner/database/test_endpoint_statistics_table.py
+++ b/test/aws/osml/model_runner/database/test_endpoint_statistics_table.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 
 import boto3
 from botocore.exceptions import ClientError
-from moto import mock_dynamodb
+from moto import mock_aws
 
 TEST_ENDPOINT_TABLE_KEY_SCHEMA = [{"AttributeName": "endpoint", "KeyType": "HASH"}]
 TEST_ENDPOINT_TABLE_ATTRIBUTE_DEFINITIONS = [
@@ -18,7 +18,7 @@ TEST_MOCK_PUT_CONDITIONAL_EXCEPTION = Mock(
 TEST_MOCK_UPDATE_EXCEPTION = Mock(side_effect=ClientError({"Error": {"Code": 500, "Message": "ClientError"}}, "update_item"))
 
 
-@mock_dynamodb
+@mock_aws
 class TestEndpointStatisticsTable(unittest.TestCase):
     def setUp(self):
         """

--- a/test/aws/osml/model_runner/database/test_feature_table.py
+++ b/test/aws/osml/model_runner/database/test_feature_table.py
@@ -8,7 +8,7 @@ import boto3
 import geojson
 from botocore.exceptions import ClientError
 from botocore.stub import ANY, Stubber
-from moto import mock_dynamodb
+from moto import mock_aws
 
 image_id = (
     "7db12549-3bcb-49c8-acba-25d46ef5cbf3:s3://spacenet-dataset/AOIs/AOI_1_Rio/srcData/mosaic_3band/013022223131.tif"  # noqa
@@ -62,7 +62,7 @@ TEST_MOCK_BATCH_WRITE_EXCEPTION = Mock(
 )
 
 
-@mock_dynamodb
+@mock_aws
 class TestFeatureTable(unittest.TestCase):
     def setUp(self):
         """

--- a/test/aws/osml/model_runner/database/test_job_table.py
+++ b/test/aws/osml/model_runner/database/test_job_table.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock
 
 import boto3
 from botocore.exceptions import ClientError
-from moto import mock_dynamodb
+from moto import mock_aws
 
 TEST_IMAGE_ID = "test-image-id"
 TEST_REGION_ID = "test-region-id"
@@ -17,7 +17,7 @@ TEST_MOCK_PUT_EXCEPTION = Mock(side_effect=ClientError({"Error": {"Code": 500, "
 TEST_MOCK_UPDATE_EXCEPTION = Mock(side_effect=ClientError({"Error": {"Code": 500, "Message": "ClientError"}}, "update_item"))
 
 
-@mock_dynamodb
+@mock_aws
 class TestJobTable(unittest.TestCase):
     def setUp(self):
         """

--- a/test/aws/osml/model_runner/database/test_region_request_table.py
+++ b/test/aws/osml/model_runner/database/test_region_request_table.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 
 import boto3
 from botocore.exceptions import ClientError
-from moto import mock_dynamodb
+from moto import mock_aws
 
 TEST_IMAGE_ID = "test-image-id"
 TEST_REGION_ID = "test-region-id"
@@ -22,7 +22,7 @@ TEST_REGION_REQUEST_TABLE_ATTRIBUTE_DEFINITIONS = [
 ]
 
 
-@mock_dynamodb
+@mock_aws
 class TestRegionRequestTable(unittest.TestCase):
     def setUp(self):
         """

--- a/test/aws/osml/model_runner/queue/test_request_queue.py
+++ b/test/aws/osml/model_runner/queue/test_request_queue.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 
 import boto3
 from botocore.exceptions import ClientError
-from moto import mock_sqs
+from moto import mock_aws
 
 TEST_MOCK_MESSAGE = {
     "Type": "Notification",
@@ -32,7 +32,7 @@ TEST_MOCK_CLIENT_EXCEPTION = Mock(
 )
 
 
-@mock_sqs
+@mock_aws
 class TestRequestQueue(unittest.TestCase):
     def setUp(self):
         from aws.osml.model_runner.app_config import BotoConfig

--- a/test/aws/osml/model_runner/status/test_sns_helper.py
+++ b/test/aws/osml/model_runner/status/test_sns_helper.py
@@ -8,13 +8,12 @@ from unittest.mock import Mock
 
 import boto3
 from botocore.exceptions import ClientError
-from moto import mock_sns, mock_sqs
+from moto import mock_aws
 
 TEST_MOCK_PUBLISH_EXCEPTION = Mock(side_effect=ClientError({"Error": {"Code": 500, "Message": "ClientError"}}, "publish"))
 
 
-@mock_sqs
-@mock_sns
+@mock_aws
 class TestSnsHelper(TestCase):
     def setUp(self):
         from aws.osml.model_runner.app_config import BotoConfig

--- a/test/aws/osml/model_runner/status/test_status_monitor.py
+++ b/test/aws/osml/model_runner/status/test_status_monitor.py
@@ -6,11 +6,10 @@ from decimal import Decimal
 from unittest import TestCase
 
 import boto3
-from moto import mock_sns, mock_sqs
+from moto import mock_aws
 
 
-@mock_sqs
-@mock_sns
+@mock_aws
 class TestStatusMonitor(TestCase):
     def setUp(self) -> None:
         from aws.osml.model_runner.app_config import BotoConfig

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -9,7 +9,7 @@ from unittest.mock import Mock, patch
 import boto3
 import geojson
 from botocore.exceptions import ClientError
-from moto import mock_dynamodb, mock_ec2, mock_kinesis, mock_s3, mock_sagemaker, mock_sns, mock_sqs
+from moto import mock_aws
 from osgeo import gdal
 
 TEST_MOCK_PUT_EXCEPTION = Mock(side_effect=ClientError({"Error": {"Code": 500, "Message": "ClientError"}}, "put_item"))
@@ -80,13 +80,7 @@ class RegionRequestMatcher:
             return other["region"] == self.region_request["region"] and other["image_id"] == self.region_request["image_id"]
 
 
-@mock_dynamodb
-@mock_ec2
-@mock_s3
-@mock_sagemaker
-@mock_sqs
-@mock_sns
-@mock_kinesis
+@mock_aws
 class TestModelRunner(TestCase):
     def setUp(self):
         """

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ deps =
     pytest-xdist>=3.2.0
     pytest-asyncio>=0.20.3
     mock>=5.0.0
-    moto>=4.1.0
+    moto[all]>=5.0.0
     defusedxml>=0.7.1
 setenv =
     # ModelRunner


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Updating the logic we use to compute the geographic extents of an image for visualization - it still isn't great but it's better and will support a broader range of imagery that is reprocessed orthorectified imagery, if it's non rectangular imagery or non-standard in other ways this bbox based approach isn't going to be flexible enough to be accurate but we can follow up on that later.

* Also updating moto implementation per it's documentation as all the tests broke with it's latest release....

*Testing*
Deployed and tested changes on various image formats in my dev account. Validated the extents are not computed correctly for the imagery that was previously failing.








By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
