### PR TITLE
feat: output structured logs with job context

### DIFF
--- a/bin/oversightml-mr-entry-point.py
+++ b/bin/oversightml-mr-entry-point.py
@@ -9,8 +9,10 @@ from types import FrameType
 from typing import Optional
 
 from codeguru_profiler_agent import Profiler
+from pythonjsonlogger import jsonlogger
 
 from aws.osml.model_runner.app import ModelRunner
+from aws.osml.model_runner.common import ThreadingLocalContextFilter
 
 
 def handler_stop_signals(signal_num: int, frame: Optional[FrameType], model_runner: ModelRunner) -> None:
@@ -18,6 +20,12 @@ def handler_stop_signals(signal_num: int, frame: Optional[FrameType], model_runn
 
 
 def configure_logging(verbose: bool) -> None:
+    """
+    This function configures the Python logging module to use a JSON formatter with and thread local context
+    variables.
+
+    :param verbose: if true the logging level will be set to DEBUG, otherwise it will be set to INFO.
+    """
     logging_level = logging.INFO
     if verbose:
         logging_level = logging.DEBUG
@@ -27,7 +35,10 @@ def configure_logging(verbose: bool) -> None:
 
     ch = logging.StreamHandler()
     ch.setLevel(logging_level)
-    formatter = logging.Formatter("%(levelname)-8s %(message)s")
+    ch.addFilter(ThreadingLocalContextFilter(["job_id", "image_id"]))
+    formatter = jsonlogger.JsonFormatter(
+        fmt="%(asctime)s %(levelname)s %(job_id)s %(image_id)s %(message)s", datefmt="%Y-%m-%dT%H:%M:%S"
+    )
     ch.setFormatter(formatter)
 
     root_logger.addHandler(ch)

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ install_requires =
     numpy>=1.24.4
     shapely>=2.0.2
     aws-embedded-metrics==3.2.0
+    python-json-logger>=2.0.0
     boto3==1.34.28
     botocore==1.34.28
     setuptools==69.0.3

--- a/src/aws/osml/model_runner/app.py
+++ b/src/aws/osml/model_runner/app.py
@@ -40,6 +40,7 @@ from .common import (
     ImageRegion,
     ImageRequestStatus,
     RegionRequestStatus,
+    ThreadingLocalContextFilter,
     Timer,
     build_embedded_metrics_config,
     get_credentials_for_assumed_role,
@@ -144,6 +145,7 @@ class ModelRunner:
             while self.running:
                 logger.debug("Checking work queue for regions to process ...")
                 (receipt_handle, region_request_attributes) = next(self.region_requests_iter)
+                ThreadingLocalContextFilter.set_context(region_request_attributes)
 
                 # If we found a region request on the queue
                 if region_request_attributes is not None:
@@ -213,6 +215,7 @@ class ModelRunner:
                         try:
                             # Parse the message into a working ImageRequest
                             image_request = ImageRequest.from_external_message(image_request_message)
+                            ThreadingLocalContextFilter.set_context(image_request.__dict__)
 
                             # Check that our image request looks good
                             if not image_request.is_valid():

--- a/src/aws/osml/model_runner/common/__init__.py
+++ b/src/aws/osml/model_runner/common/__init__.py
@@ -8,6 +8,7 @@ from .auto_string_enum import AutoStringEnum
 from .credentials_utils import get_credentials_for_assumed_role
 from .endpoint_utils import EndpointUtils
 from .exceptions import InvalidAssumedRoleException, InvalidClassificationException
+from .log_context import ThreadingLocalContextFilter
 from .metrics_utils import build_embedded_metrics_config
 from .mr_post_processing import (
     FeatureDistillationAlgorithm,

--- a/src/aws/osml/model_runner/common/log_context.py
+++ b/src/aws/osml/model_runner/common/log_context.py
@@ -1,0 +1,39 @@
+import logging
+import threading
+from typing import List, Optional
+
+_LOG_CONTEXT = threading.local()
+
+
+class ThreadingLocalContextFilter(logging.Filter):
+    """
+    This is a filter that injects contextual information into the log message. The contextual information is
+    set using the static methods of this class.
+    """
+
+    def __init__(self, attribute_names: List[str]):
+        super().__init__()
+        self.attribute_names = attribute_names
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """
+        This method is called for each log record. It injects the contextual information into the log record.
+
+        :param record: the log record to filter
+        :return: True, this filter does not exclude information from the log
+        """
+        for attribute_name in self.attribute_names:
+            setattr(record, attribute_name, getattr(_LOG_CONTEXT, attribute_name, None))
+        return True
+
+    @staticmethod
+    def set_context(context: Optional[dict]):
+        """
+        Set the context for the current thread. If None all context information is cleared.
+
+        :param context: dict = the context to set
+        """
+        if context is None:
+            _LOG_CONTEXT.__dict__.clear()
+        else:
+            _LOG_CONTEXT.__dict__.update(context)

--- a/src/aws/osml/model_runner/status/status_monitor.py
+++ b/src/aws/osml/model_runner/status/status_monitor.py
@@ -33,8 +33,14 @@ class StatusMonitor:
             and image_request_item.processing_time is not None
         ):
             try:
-                status_message = f"StatusMonitor update: {status} {image_request_item.job_id}: {message}"
-                logging.info(status_message)
+                logging.info(
+                    "StatusMonitorUpdate",
+                    extra={
+                        "reason": message,
+                        "status": status,
+                        "request": image_request_item.__dict__,
+                    },
+                )
 
                 sns_message_attributes = ImageRequestStatusMessage(
                     image_status=status,
@@ -44,6 +50,7 @@ class StatusMonitor:
                     processing_duration=image_request_item.processing_time,
                 )
 
+                status_message = f"StatusMonitor update: {status} {image_request_item.job_id}: {message}"
                 self.image_status_sns.publish_message(
                     status_message,
                     sns_message_attributes.asdict_str_values(),

--- a/src/aws/osml/model_runner/tile_worker/tile_worker.py
+++ b/src/aws/osml/model_runner/tile_worker/tile_worker.py
@@ -13,7 +13,7 @@ from shapely.affinity import translate
 from shapely.geometry import Polygon
 
 from aws.osml.model_runner.app_config import MetricLabels
-from aws.osml.model_runner.common import GeojsonDetectionField
+from aws.osml.model_runner.common import GeojsonDetectionField, ThreadingLocalContextFilter
 from aws.osml.model_runner.database import FeatureTable
 from aws.osml.model_runner.inference import Detector
 from aws.osml.model_runner.tile_worker import FeatureRefinery
@@ -40,6 +40,7 @@ class TileWorker(Thread):
         asyncio.set_event_loop(thread_event_loop)
         while True:
             image_info: Dict = self.in_queue.get()
+            ThreadingLocalContextFilter.set_context(image_info)
 
             if image_info is None:
                 logging.info("All images processed. Stopping tile worker.")

--- a/src/aws/osml/model_runner/tile_worker/tile_worker_utils.py
+++ b/src/aws/osml/model_runner/tile_worker/tile_worker_utils.py
@@ -187,6 +187,7 @@ def process_tiles(
                         "image_path": tmp_image_path,
                         "region": tile_bounds,
                         "image_id": region_request.image_id,
+                        "job_id": region_request.job_id,
                     }
                     # Increment our tile count tracking
                     total_tile_count += 1

--- a/test/aws/osml/model_runner/common/test_log_context.py
+++ b/test/aws/osml/model_runner/common/test_log_context.py
@@ -1,0 +1,33 @@
+import logging
+from threading import Thread
+from unittest import TestCase, main
+
+
+class TestThread(TestCase):
+    def test_filter_adds_thread_local_context(self):
+        from aws.osml.model_runner.common import ThreadingLocalContextFilter
+
+        context_filter = ThreadingLocalContextFilter(attribute_names=["context_value"])
+        context_filter.set_context({"context_value": "A"})
+        test_log_record = logging.LogRecord("test-name", logging.DEBUG, "some_module.py", 1, "test message", None, None)
+        assert context_filter.filter(test_log_record) is True
+        assert test_log_record.context_value == "A"
+
+        thread_log_record = logging.LogRecord("test-name", logging.DEBUG, "some_module.py", 1, "test message", None, None)
+
+        def sample_task():
+            context_filter.set_context({"context_value": "B"})
+            context_filter.filter(thread_log_record) is True
+
+        thread = Thread(target=sample_task)
+        thread.start()
+        thread.join()
+        assert thread_log_record.context_value == "B"
+
+        test_log_record = logging.LogRecord("test-name", logging.DEBUG, "some_module.py", 1, "test message", None, None)
+        assert context_filter.filter(test_log_record) is True
+        assert test_log_record.context_value == "A"
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
These changes update all of the Python logging calls in ModelRunner to output JSON structured log records. Each of these log records will have the job_id and image_id of the request which will allow operators to quickly search for all logs associated with a specific job_id which will aggregate and filter results from across the cluster. These updates also enable more complex analysis and visualization of log records using CloudWatch log insights.

NEW DEPENDENCY: python-json-logger >= 2.0.0
 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
