### PR TITLE
feat: new standardized metrics with dimensions

### DIFF
--- a/bin/oversightml-mr-entry-point.py
+++ b/bin/oversightml-mr-entry-point.py
@@ -37,7 +37,7 @@ def configure_logging(verbose: bool) -> None:
     ch.setLevel(logging_level)
     ch.addFilter(ThreadingLocalContextFilter(["job_id", "image_id"]))
     formatter = jsonlogger.JsonFormatter(
-        fmt="%(asctime)s %(levelname)s %(job_id)s %(image_id)s %(message)s", datefmt="%Y-%m-%dT%H:%M:%S"
+        fmt="%(levelname)s %(message)s %(job_id)s %(image_id)s", datefmt="%Y-%m-%dT%H:%M:%S"
     )
     ch.setFormatter(formatter)
 

--- a/src/aws/osml/model_runner/app_config.py
+++ b/src/aws/osml/model_runner/app_config.py
@@ -89,32 +89,28 @@ class MetricLabels(str, Enum):
     Enumeration defining the metric labels used by OSML
     """
 
-    ENDPOINT_LATENCY = "EndpointLatency"
-    ENDPOINT_RETRY_COUNT = "EndpointRetryCount"
-    FEATURE_AGG_LATENCY = "FeatureAggLatency"
-    FEATURE_SELECTION_LATENCY = "FeatureSelectionLatency"
-    FEATURE_ERROR = "FeatureError"
-    FEATURE_STORE_LATENCY = "FeatureStoreLatency"
-    IMAGE_PROCESSING_ERROR = "ImageProcessingError"
-    METADATA_LATENCY = "MetadataLatency"
-    MODEL_INVOCATION = "ModelInvocation"
-    MODEL_ERROR = "ModelError"
-    REGION_LATENCY = "RegionLatency"
-    REGION_PROCESSING_ERROR = "RegionProcessingError"
-    REGIONS_PROCESSED = "RegionsProcessed"
-    REGIONS_SELF_THROTTLED = "RegionsSelfThrottled"
-    TILING_LATENCY = "TilingLatency"
-    TILES_PROCESSED = "TilesProcessed"
-    IMAGE_LATENCY = ("ImageLatency",)
-    FEATURE_DECODE = "FeatureDecodeError"
-    FEATURE_MISSING_GEO = "FeatureMissingGeometry"
-    FEATURE_TO_SHAPE = "FeatureToShapeConversion"
-    FEATURE_UPDATE = "FeatureUpdateFailure"
-    FEATURE_UPDATE_EXCEPTION = "FeatureUpdateException"
-    INVALID_REQUEST = "InvalidRequest"
-    INVALID_ROI = "InvalidROI"
-    NO_IMAGE_URL = "NoImageURL"
-    PROCESSING_FAILURE = "ProcessingFailure"
-    TILE_PROCESSING_ERROR = "TileProcessingError"
-    TILE_CREATION_FAILURE = "TileCreationFailure"
-    UNSUPPORTED_MODEL_HOST = "UnsupportedModelHost"
+    # These are based on common metric names used by a variety of AWS services (e.g. Lambda)
+    DURATION = "Duration"
+    INVOCATIONS = "Invocations"
+    ERRORS = "Errors"
+    THROTTLES = "Throttles"
+    RETRIES = "Retries"
+
+    # These dimensions allow us to limit the scope of a metric value to a particular portion of the
+    # ModelRunner application, a data type, or input format.
+    OPERATION_DIMENSION = "Operation"
+    MODEL_NAME_DIMENSION = "ModelName"
+    INPUT_FORMAT_DIMENSION = "InputFormat"
+
+    # These operation names can be used along with the Operation dimension to restrict the scope
+    # of the common metrics to a specific portion of the ModelRunner application.
+    IMAGE_PROCESSING_OPERATION = "ImageProcessing"
+    REGION_PROCESSING_OPERATION = "RegionProcessing"
+    TILE_GENERATION_OPERATION = "TileGeneration"
+    TILE_PROCESSING_OPERATION = "TileProcessing"
+    MODEL_INVOCATION_OPERATION = "ModelInvocation"
+    FEATURE_REFINEMENT_OPERATION = "FeatureRefinement"
+    FEATURE_STORAGE_OPERATION = "FeatureStorage"
+    FEATURE_AGG_OPERATION = "FeatureAggregation"
+    FEATURE_SELECTION_OPERATION = "FeatureSelection"
+    FEATURE_DISSEMINATE_OPERATION = "FeatureDissemination"

--- a/src/aws/osml/model_runner/common/metrics_utils.py
+++ b/src/aws/osml/model_runner/common/metrics_utils.py
@@ -10,5 +10,5 @@ def build_embedded_metrics_config():
     metrics_config = get_config()
     metrics_config.service_name = "OSML"
     metrics_config.log_group_name = "/aws/OSML/MRService"
-    metrics_config.namespace = "OSML"
+    metrics_config.namespace = "OSML/ModelRunner"
     metrics_config.environment = "local"

--- a/src/aws/osml/model_runner/tile_worker/tile_worker.py
+++ b/src/aws/osml/model_runner/tile_worker/tile_worker.py
@@ -5,18 +5,22 @@ import logging
 from datetime import datetime, timezone
 from queue import Queue
 from threading import Thread
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
+import geojson
 from aws_embedded_metrics.logger.metrics_logger import MetricsLogger
+from aws_embedded_metrics.metric_scope import metric_scope
 from aws_embedded_metrics.unit import Unit
 from shapely.affinity import translate
 from shapely.geometry import Polygon
 
 from aws.osml.model_runner.app_config import MetricLabels
-from aws.osml.model_runner.common import GeojsonDetectionField, ThreadingLocalContextFilter
+from aws.osml.model_runner.common import GeojsonDetectionField, ThreadingLocalContextFilter, Timer
 from aws.osml.model_runner.database import FeatureTable
 from aws.osml.model_runner.inference import Detector
 from aws.osml.model_runner.tile_worker import FeatureRefinery
+
+logger = logging.getLogger(__name__)
 
 
 class TileWorker(Thread):
@@ -26,14 +30,12 @@ class TileWorker(Thread):
         feature_detector: Detector,
         feature_refinery: Optional[FeatureRefinery],
         feature_table: FeatureTable,
-        metrics: MetricsLogger,
     ) -> None:
         super().__init__()
         self.in_queue = in_queue
         self.feature_detector = feature_detector
         self.feature_refinery = feature_refinery
         self.feature_table = feature_table
-        self.metrics = metrics
 
     def run(self) -> None:
         thread_event_loop = asyncio.new_event_loop()
@@ -52,55 +54,7 @@ class TileWorker(Thread):
                 break
 
             try:
-                logging.info("Invoking Feature Detector Endpoint")
-                with open(image_info["image_path"], mode="rb") as payload:
-                    feature_collection = self.feature_detector.find_features(payload)
-
-                # Convert the features to reference the full image
-                features = []
-                ulx = image_info["region"][0][1]
-                uly = image_info["region"][0][0]
-                if isinstance(feature_collection, dict) and "features" in feature_collection:
-                    logging.info("SM Model returned {} features".format(len(feature_collection["features"])))
-                    for feature in feature_collection["features"]:
-                        # model returned a mask
-                        scaled_polygon = None
-                        if GeojsonDetectionField.GEOM in feature["properties"]:
-                            polygon = Polygon(feature["properties"][GeojsonDetectionField.GEOM])
-                            scaled_polygon = translate(polygon, xoff=ulx, yoff=uly)
-                            feature["properties"][GeojsonDetectionField.GEOM] = list(scaled_polygon.exterior.coords)
-                        # model returned a bounding box
-                        if GeojsonDetectionField.BOUNDS in feature["properties"]:
-                            tile_bbox = feature["properties"][GeojsonDetectionField.BOUNDS]
-                            scaled_bbox = translate(
-                                Polygon(FeatureRefinery.imcoords_bbox_to_polygon(tile_bbox)), xoff=ulx, yoff=uly
-                            )
-                            feature["properties"][GeojsonDetectionField.BOUNDS] = scaled_bbox.bounds
-                        elif scaled_polygon is not None:
-                            feature["properties"][GeojsonDetectionField.BOUNDS] = scaled_polygon.bounds
-                        else:
-                            logging.warning(f"There isn't a valid detection shape for feature: {feature}")
-                        feature["properties"]["image_id"] = image_info["image_id"]
-                        feature["properties"]["inferenceTime"] = datetime.now(tz=timezone.utc).isoformat()
-                        FeatureRefinery.feature_property_transformation(feature)
-                        features.append(feature)
-
-                logging.info("# Features Created: {}".format(len(features)))
-                if len(features) > 0:
-                    if self.feature_refinery is not None:
-                        # Create a geometry for each feature in the result. The geographic coordinates of these
-                        # features are computed using the sensor model provided in the image metadata
-                        self.feature_refinery.refine_features_for_tile(features)
-                        logging.info("Created Geographic Coordinates for {} features".format(len(features)))
-
-                    self.feature_table.add_features(features)
-            except Exception as e:
-                logging.error("Failed to process region tile!")
-                logging.exception(e)
-                self.feature_detector.error_count += 1  # borrow the feature detector error count to tally other errors
-                if self.metrics:
-                    self.metrics.put_metric(MetricLabels.TILE_PROCESSING_ERROR, 1, str(Unit.COUNT.value))
-                    self.metrics.put_metric(MetricLabels.TILE_CREATION_FAILURE, 1, str(Unit.COUNT.value))
+                self.process_tile(image_info)
             finally:
                 self.in_queue.task_done()
 
@@ -110,3 +64,110 @@ class TileWorker(Thread):
         except Exception as e:
             logging.warning("Failed to stop and close the thread event loop")
             logging.exception(e)
+
+    @metric_scope
+    def process_tile(self, image_info: Dict, metrics: MetricsLogger = None) -> None:
+        """
+        This method handles the processing of a single tile by invoking the ML model, geolocating the detections to
+        create features and finally storing the features in the database.
+
+        :param image_info: description of the tile to be processed
+        :param metrics: the current metric scope
+        """
+        if isinstance(metrics, MetricsLogger):
+            metrics.set_dimensions()
+            metrics.put_dimensions(
+                {
+                    MetricLabels.OPERATION_DIMENSION: MetricLabels.TILE_PROCESSING_OPERATION,
+                    MetricLabels.MODEL_NAME_DIMENSION: self.feature_detector.endpoint,
+                }
+            )
+            metrics.put_metric(MetricLabels.INVOCATIONS, 1, str(Unit.COUNT.value))
+
+        try:
+            with Timer(
+                task_str=f"Processing Tile {image_info['image_path']}",
+                metric_name=MetricLabels.DURATION,
+                logger=logger,
+                metrics_logger=metrics,
+            ):
+                with open(image_info["image_path"], mode="rb") as payload:
+                    feature_collection = self.feature_detector.find_features(payload)
+
+                features = self._refine_features(feature_collection, image_info)
+
+                if len(features) > 0:
+                    self.feature_table.add_features(features)
+
+        except Exception as e:
+            logging.error("Failed to process region tile!")
+            logging.exception(e)
+            self.feature_detector.error_count += 1  # borrow the feature detector error count to tally other errors
+            if isinstance(metrics, MetricsLogger):
+                metrics.put_metric(MetricLabels.ERRORS, 1, str(Unit.COUNT.value))
+
+    @metric_scope
+    def _refine_features(self, feature_collection, image_info: Dict, metrics: MetricsLogger = None) -> List[geojson.Feature]:
+        """
+        This method converts the detections returned by the model into geolocated features. It first updates the
+        image coordinates of each detection to be in relation to the full image then it geolocates the image feature.
+
+        :param feature_collection: the features from the ML model
+        :param image_info: a description of the image tile containing the features
+        :param metrics: the current metric scope
+        :return: a list of GeoJSON features
+        """
+        if isinstance(metrics, MetricsLogger):
+            metrics.set_dimensions()
+            metrics.put_dimensions(
+                {
+                    MetricLabels.OPERATION_DIMENSION: MetricLabels.FEATURE_REFINEMENT_OPERATION,
+                }
+            )
+
+        with Timer(
+            task_str=f"Refining Features for Tile:{image_info['image_path']}",
+            metric_name=MetricLabels.DURATION,
+            logger=logger,
+            metrics_logger=metrics,
+        ):
+            # TODO: Consider move invocations to Timer
+            if isinstance(metrics, MetricsLogger):
+                metrics.put_metric(MetricLabels.INVOCATIONS, 1, str(Unit.COUNT.value))
+
+            features = []
+            ulx = image_info["region"][0][1]
+            uly = image_info["region"][0][0]
+            if isinstance(feature_collection, dict) and "features" in feature_collection:
+                logging.info("SM Model returned {} features".format(len(feature_collection["features"])))
+                for feature in feature_collection["features"]:
+                    # model returned a mask
+                    scaled_polygon = None
+                    if GeojsonDetectionField.GEOM in feature["properties"]:
+                        polygon = Polygon(feature["properties"][GeojsonDetectionField.GEOM])
+                        scaled_polygon = translate(polygon, xoff=ulx, yoff=uly)
+                        feature["properties"][GeojsonDetectionField.GEOM] = list(scaled_polygon.exterior.coords)
+                    # model returned a bounding box
+                    if GeojsonDetectionField.BOUNDS in feature["properties"]:
+                        tile_bbox = feature["properties"][GeojsonDetectionField.BOUNDS]
+                        scaled_bbox = translate(
+                            Polygon(FeatureRefinery.imcoords_bbox_to_polygon(tile_bbox)), xoff=ulx, yoff=uly
+                        )
+                        feature["properties"][GeojsonDetectionField.BOUNDS] = scaled_bbox.bounds
+                    elif scaled_polygon is not None:
+                        feature["properties"][GeojsonDetectionField.BOUNDS] = scaled_polygon.bounds
+                    else:
+                        logging.warning(f"There isn't a valid detection shape for feature: {feature}")
+                    feature["properties"]["image_id"] = image_info["image_id"]
+                    feature["properties"]["inferenceTime"] = datetime.now(tz=timezone.utc).isoformat()
+                    FeatureRefinery.feature_property_transformation(feature)
+                    features.append(feature)
+            logging.info("# Features Created: {}".format(len(features)))
+            if len(features) > 0:
+                if self.feature_refinery is not None:
+                    # Create a geometry for each feature in the result. The geographic coordinates of these
+                    # features are computed using the sensor model provided in the image metadata
+                    self.feature_refinery.refine_features_for_tile(features)
+                    logging.info("Created Geographic Coordinates for {} features".format(len(features)))
+
+        return features

--- a/test/aws/osml/model_runner/tile_worker/test_tile_worker_utils.py
+++ b/test/aws/osml/model_runner/tile_worker/test_tile_worker_utils.py
@@ -30,10 +30,7 @@ class TestTileWorkerUtils(TestCase):
         )
         mock_sensor_model = None
         mock_elevation_model = None
-        mock_metrics = None
-        work_queue, tile_worker_list = setup_tile_workers(
-            mock_region_request, mock_sensor_model, mock_elevation_model, mock_metrics
-        )
+        work_queue, tile_worker_list = setup_tile_workers(mock_region_request, mock_sensor_model, mock_elevation_model)
         assert len(tile_worker_list) == mock_num_tile_workers
 
     @patch("aws.osml.model_runner.tile_worker.tile_worker_utils.FeatureTable", autospec=True)
@@ -62,10 +59,9 @@ class TestTileWorkerUtils(TestCase):
         )
         mock_sensor_model = None
         mock_elevation_model = None
-        mock_metrics = None
         with self.assertRaises(SetupTileWorkersException):
             # with self.assertRaises(ValueError):
-            setup_tile_workers(mock_region_request, mock_sensor_model, mock_elevation_model, mock_metrics)
+            setup_tile_workers(mock_region_request, mock_sensor_model, mock_elevation_model)
 
     def test_chip_generator(self):
         from aws.osml.model_runner.tile_worker.tile_worker_utils import generate_crops

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -547,8 +547,12 @@ class TestModelRunner(TestCase):
         from aws.osml.gdal.gdal_utils import load_gdal_dataset
         from aws.osml.model_runner.database.endpoint_statistics_table import EndpointStatisticsTable
         from aws.osml.model_runner.database.job_table import JobTable
-        from aws.osml.model_runner.database.region_request_table import RegionRequestTable
+        from aws.osml.model_runner.database.region_request_table import RegionRequestItem, RegionRequestTable
         from aws.osml.model_runner.exceptions import SelfThrottledRegionException
+
+        region_request_item = RegionRequestItem(
+            image_id=TEST_IMAGE_ID, region_id="test-region-id", region_pixel_bounds="(0, 0)(50, 50)"
+        )
 
         # Load up our test image
         raster_dataset, sensor_model = load_gdal_dataset(self.region_request.image_url)
@@ -559,7 +563,7 @@ class TestModelRunner(TestCase):
         self.model_runner.endpoint_statistics_table.current_in_progress_regions.return_value = 10000
 
         with self.assertRaises(SelfThrottledRegionException):
-            self.model_runner.process_region_request(self.region_request, raster_dataset, sensor_model)
+            self.model_runner.process_region_request(self.region_request, region_request_item, raster_dataset, sensor_model)
 
         self.model_runner.endpoint_statistics_table.increment_region_count.assert_not_called()
         self.model_runner.endpoint_statistics_table.decrement_region_count.assert_not_called()


### PR DESCRIPTION
These changes replace the existing CloudWatch metrics generated by ModelRunner with a new set that are more inline with AWS conventions. Key changes include:
- Moving the metrics to the OSML/ModelRunner Namespace to deconflict with other OversightML project metrics.
- Standardized metric names for Duration, Invocations, Errors, Retries, and Throttles
- Use of the Operation dimension to associated metrics with a specific phase of the MR processing. 
- Introduction of the InputFormat and ModelName dimensions to further differentiate metrics for key inputs.

A companion CR including changes to the osml-cdk-constructs will be published to update the dashboard examples. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
