### PR TITLE
build(fix): Add ref tag to cut submodule PR to guidance repo

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -1,7 +1,7 @@
 name: notify
 
 on:
-  push:
+  pull_request:
     branches: ["main"]
 
 jobs:
@@ -13,5 +13,6 @@ jobs:
       with:
         repo: aws-solutions-library-samples/guidance-for-overhead-imagery-inference-on-aws
         workflow: osml_update_submodules.yml
+        ref: dev
         token: ${{ secrets.GUIDANCE_OSML_SUBMODULES_ACTION_10_24 }}
         inputs: '{ "DISPATCH_REPO_NAME" : "${{ github.event.repository.name }}", "DISPATCH_REPO_SHA": "${{ env.SHA }}" }'

--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -1,7 +1,7 @@
 name: notify
 
 on:
-  pull_request:
+  push:
     branches: ["main"]
 
 jobs:


### PR DESCRIPTION
**Issue #, if available:** n/a

### Notes
- Without the `ref` (optional property), it will default to to whichever branch it got merged in (for example: main) and will try to cut PR against the <name> (in this case: main) branch in guidance repo. Since we do not have `dev` branch anymore, we would need to set the `ref` as `dev` so it can cut PR against the dev branch in guidance repo. 

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
