### PR TITLE
fix: deprecate job_arn request parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ To start a job, place an ImageRequest on the ImageRequestQueue.
 Sample ImageRequest:
 ```json
 {
-    "jobArn": "arn:aws:oversightml:<REGION>:<ACCOUNT>:ipj/<job_name>",
     "jobName": "<job_name>",
     "jobId": "<job_id>",
     "imageUrls": ["<image_url>"],

--- a/src/aws/osml/model_runner/api/image_request.py
+++ b/src/aws/osml/model_runner/api/image_request.py
@@ -52,7 +52,6 @@ class ImageRequest(object):
         ]
 
         self.job_id: str = ""
-        self.job_arn: str = ""
         self.image_id: str = ""
         self.image_url: str = ""
         self.image_read_role: str = ""
@@ -101,7 +100,6 @@ class ImageRequest(object):
         if "imageProcessorTileCompression" in image_request:
             properties["tile_compression"] = image_request["imageProcessorTileCompression"]
 
-        properties["job_arn"] = image_request["jobArn"]
         properties["job_id"] = image_request["jobId"]
 
         properties["image_url"] = image_request["imageUrls"][0]
@@ -153,8 +151,8 @@ class ImageRequest(object):
             logger.error("Invalid shared properties in ImageRequest")
             return False
 
-        if not self.job_arn or not self.job_id or not self.outputs:
-            logger.error("Missing job arn, job id, or outputs properties in ImageRequest")
+        if not self.job_id or not self.outputs:
+            logger.error("Missing job id or outputs properties in ImageRequest")
             return False
 
         num_feature_detection_options = len(self.get_feature_distillation_option())

--- a/src/aws/osml/model_runner/app.py
+++ b/src/aws/osml/model_runner/app.py
@@ -235,11 +235,9 @@ class ModelRunner:
                             logger.error(f"There was a problem processing the image request: {err}")
                             min_image_id = image_request.image_id if image_request and image_request.image_id else ""
                             min_job_id = image_request.job_id if image_request and image_request.job_id else ""
-                            min_job_arn = image_request.job_arn if image_request and image_request.job_arn else ""
                             minimal_job_item = JobItem(
                                 image_id=min_image_id,
                                 job_id=min_job_id,
-                                job_arn=min_job_arn,
                                 processing_time=Decimal(0),
                             )
                             self.fail_image_request_send_messages(minimal_job_item, err)
@@ -274,7 +272,6 @@ class ModelRunner:
             image_request_item = JobItem(
                 image_id=image_request.image_id,
                 job_id=image_request.job_id,
-                job_arn=image_request.job_arn,
                 tile_size=str(image_request.tile_size),
                 tile_overlap=str(image_request.tile_overlap),
                 model_name=image_request.model_name,
@@ -345,7 +342,6 @@ class ModelRunner:
                 minimal_job_item = JobItem(
                     image_id=image_request.image_id,
                     job_id=image_request.job_id,
-                    job_arn=image_request.job_arn,
                     processing_time=Decimal(0),
                 )
                 self.fail_image_request(minimal_job_item, err)

--- a/src/aws/osml/model_runner/database/job_table.py
+++ b/src/aws/osml/model_runner/database/job_table.py
@@ -37,7 +37,6 @@ class JobItem(DDBItem):
 
     image_id: str
     job_id: Optional[str] = None
-    job_arn: Optional[str] = None
     image_url: Optional[str] = None
     image_read_role: Optional[str] = None
     model_invoke_mode: Optional[str] = None

--- a/src/aws/osml/model_runner/status/image_request_status.py
+++ b/src/aws/osml/model_runner/status/image_request_status.py
@@ -16,7 +16,6 @@ from aws.osml.model_runner.sink import Sink
 class ImageRequestStatusMessage:
     image_status: ImageRequestStatus
     job_id: str
-    job_arn: Optional[str] = None
     image_id: Optional[str] = None
     image_url: Optional[str] = None
     image_read_role: Optional[str] = None

--- a/src/aws/osml/model_runner/status/status_monitor.py
+++ b/src/aws/osml/model_runner/status/status_monitor.py
@@ -28,7 +28,6 @@ class StatusMonitor:
         # Check that the image request has valid properties
         if (
             image_request_item.job_id is not None
-            and image_request_item.job_arn is not None
             and image_request_item.image_id is not None
             and image_request_item.processing_time is not None
         ):
@@ -45,7 +44,6 @@ class StatusMonitor:
                 sns_message_attributes = ImageRequestStatusMessage(
                     image_status=status,
                     job_id=image_request_item.job_id,
-                    job_arn=image_request_item.job_arn,
                     image_id=image_request_item.image_id,
                     processing_duration=image_request_item.processing_time,
                 )

--- a/test/aws/osml/model_runner/api/test_image_request.py
+++ b/test/aws/osml/model_runner/api/test_image_request.py
@@ -25,16 +25,6 @@ class TestImageRequest(unittest.TestCase):
 
         assert not ir.is_valid()
 
-    def test_invalid_job_arn(self):
-        from aws.osml.model_runner.api.image_request import ImageRequest
-
-        ir = ImageRequest(
-            self.sample_request_data,
-            job_arn="",
-        )
-
-        assert not ir.is_valid()
-
     def test_invalid_job_id(self):
         from aws.osml.model_runner.api.image_request import ImageRequest
 
@@ -48,7 +38,6 @@ class TestImageRequest(unittest.TestCase):
     @staticmethod
     def build_request_data():
         return {
-            "job_arn": "arn:aws:oversightml:us-east-1:012345678910:ipj/test-job",
             "job_id": "test-job",
             "image_id": "test-image-id",
             "image_url": "test-image-url",

--- a/test/aws/osml/model_runner/queue/test_request_queue.py
+++ b/test/aws/osml/model_runner/queue/test_request_queue.py
@@ -17,10 +17,6 @@ TEST_MOCK_MESSAGE = {
         "job_id": {"Type": "String", "Value": "0"},
         "processing_duration": {"Type": "String", "Value": "0.290897369384765625"},
         "image_status": {"Type": "String", "Value": "IN_PROGRESS"},
-        "job_arn": {
-            "Type": "String",
-            "Value": "arn:aws:oversightml:us-west-2:012345678910:ipj/test-0",
-        },
         "image_id": {"Type": "String", "Value": "0:s3://test-images-012345678910/images/small.ntf"},
     },
 }

--- a/test/aws/osml/model_runner/status/test_image_request_status.py
+++ b/test/aws/osml/model_runner/status/test_image_request_status.py
@@ -15,7 +15,6 @@ class TestImageRequestStatus(TestCase):
 
         self.mock_image_status = ImageRequestStatus.IN_PROGRESS
         self.mock_job_id = "job id"
-        self.mock_job_arn = "job arn"
         self.mock_image_id = "image id"
         self.mock_image_url = "https://image-link.ntf"
         self.mock_image_read_role = "ImageReader"
@@ -40,7 +39,6 @@ class TestImageRequestStatus(TestCase):
         mock_item = ImageRequestStatusMessage(
             image_status=self.mock_image_status,
             job_id=self.mock_job_id,
-            job_arn=self.mock_job_arn,
             image_id=self.mock_image_id,
             image_url=self.mock_image_url,
             image_read_role=self.mock_image_read_role,
@@ -59,7 +57,6 @@ class TestImageRequestStatus(TestCase):
         expected_dict_of_strings = {
             "image_status": str(self.mock_image_status.value),
             "job_id": self.mock_job_id,
-            "job_arn": self.mock_job_arn,
             "image_id": self.mock_image_id,
             "image_url": self.mock_image_url,
             "image_read_role": self.mock_image_read_role,

--- a/test/aws/osml/model_runner/status/test_status_monitor.py
+++ b/test/aws/osml/model_runner/status/test_status_monitor.py
@@ -42,14 +42,12 @@ class TestStatusMonitor(TestCase):
         from aws.osml.model_runner.common.typing import ImageRequestStatus
 
         self.job_item.job_id = "1234"
-        self.job_item.job_arn = "arn"
         self.job_item.processing_time = Decimal(1)
         mock_message = "test message 1"
         mock_status = ImageRequestStatus.SUCCESS
         expected_attributes = {
             "image_status": {"Type": "String", "Value": mock_status.value},
             "job_id": {"Type": "String", "Value": self.job_item.job_id},
-            "job_arn": {"Type": "String", "Value": self.job_item.job_arn},
             "image_id": {"Type": "String", "Value": self.job_item.image_id},
             "processing_duration": {"Type": "String", "Value": str(self.job_item.processing_time)},
         }
@@ -61,7 +59,6 @@ class TestStatusMonitor(TestCase):
             MessageAttributeNames=[
                 "image_status",
                 "job_id",
-                "job_arn",
                 "image_id",
                 "processing_duration",
             ],
@@ -76,7 +73,6 @@ class TestStatusMonitor(TestCase):
         from aws.osml.model_runner.status.status_monitor import StatusMonitorException
 
         self.job_item.job_id = "1234"
-        self.job_item.job_arn = "arn"
         self.job_item.processing_time = Decimal(1)
         self.status_monitor.image_status_sns.topic_arn = "topic:arn:that:does:not:exist"
         with self.assertRaises(StatusMonitorException):
@@ -89,13 +85,6 @@ class TestStatusMonitor(TestCase):
         with self.assertRaises(StatusMonitorException):
             self.status_monitor.process_event(self.job_item, ImageRequestStatus.SUCCESS, "test")
         self.job_item.job_id = "1234"
-        with self.assertRaises(StatusMonitorException):
-            self.status_monitor.process_event(self.job_item, ImageRequestStatus.SUCCESS, "test")
-        self.job_item.job_arn = "arn"
-        with self.assertRaises(StatusMonitorException):
-            self.status_monitor.process_event(self.job_item, ImageRequestStatus.SUCCESS, "test")
-        self.job_item.job_arn = None
-        self.job_item.processing_time = Decimal(1)
         with self.assertRaises(StatusMonitorException):
             self.status_monitor.process_event(self.job_item, ImageRequestStatus.SUCCESS, "test")
 

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -12,7 +12,6 @@ from botocore.stub import Stubber
 TEST_S3_FULL_BUCKET_PATH = "s3://test-results-bucket/test/data/small.ntf"
 
 base_request = {
-    "jobArn": "arn:aws:oversightml:us-east-1:012345678910:ipj/test-job",
     "jobName": "test-job",
     "jobId": "5f4e8a55-95cf-4d96-95cd-9b037f767eff",
     "imageUrls": ["s3://fake-bucket/images/test-image-id"],
@@ -79,7 +78,6 @@ class TestModelRunnerAPI(TestCase):
         }
         ir = ImageRequest(
             image_request_template,
-            job_arn="arn:aws:oversightml:us-east-1:012345678910:ipj/test-job",
             job_name="test-job",
             job_id="5f4e8a55-95cf-4d96-95cd-9b037f767eff",
             image_id="5f4e8a55-95cf-4d96-95cd-9b037f767eff:s3://fake-bucket/images/test-image-id",
@@ -99,7 +97,6 @@ class TestModelRunnerAPI(TestCase):
         assert ir.tile_format == "NITF"
         assert ir.tile_compression == ImageCompression.NONE
         assert ir.job_id == "5f4e8a55-95cf-4d96-95cd-9b037f767eff"
-        assert ir.job_arn == "arn:aws:oversightml:us-east-1:012345678910:ipj/test-job"
         assert len(ir.outputs) == 1
         sinks = SinkFactory.outputs_to_sinks(ir.outputs)
         s3_sink: Sink = sinks[0]
@@ -159,7 +156,6 @@ class TestModelRunnerAPI(TestCase):
         assert ir.tile_format == "PNG"
         assert ir.tile_compression == ImageCompression.NONE
         assert ir.job_id == "5f4e8a55-95cf-4d96-95cd-9b037f767eff"
-        assert ir.job_arn == "arn:aws:oversightml:us-east-1:012345678910:ipj/test-job"
         assert len(ir.outputs) == 1
         sinks = SinkFactory.outputs_to_sinks(ir.outputs)
         s3_sink: Sink = sinks[0]
@@ -192,7 +188,6 @@ class TestModelRunnerAPI(TestCase):
         assert ir.tile_format == "NITF"
         assert ir.tile_compression == ImageCompression.NONE
         assert ir.job_id == "5f4e8a55-95cf-4d96-95cd-9b037f767eff"
-        assert ir.job_arn == "arn:aws:oversightml:us-east-1:012345678910:ipj/test-job"
         assert len(ir.outputs) == 1
         sinks = SinkFactory.outputs_to_sinks(ir.outputs)
         s3_sink: Sink = sinks[0]
@@ -235,7 +230,6 @@ class TestModelRunnerAPI(TestCase):
         assert ir.tile_format == "NITF"
         assert ir.tile_compression == ImageCompression.NONE
         assert ir.job_id == "5f4e8a55-95cf-4d96-95cd-9b037f767eff"
-        assert ir.job_arn == "arn:aws:oversightml:us-east-1:012345678910:ipj/test-job"
         assert len(ir.outputs) == 2
         sinks = SinkFactory.outputs_to_sinks(ir.outputs)
         s3_sink: Sink = sinks[0]

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,9 @@ envlist =
 
 # Pre distribution checks for the package
     twine
-requires = tox-conda
+requires =
+    setuptools
+    tox-conda
 skip_missing_interpreters = False
 
 [testenv]


### PR DESCRIPTION
**Issue #, if available:** n/a

### Notes
- The "job_arn" parameter is redundant with "job_id" and therefore not needed. This will not break any changes.

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
