### PR TITLE
fix: rename sync to sink

### DIFF
--- a/src/aws/osml/model_runner/app.py
+++ b/src/aws/osml/model_runner/app.py
@@ -647,7 +647,7 @@ class ModelRunner:
             features = self.add_properties_to_features(image_request_item, features)
 
             # Sink the features into the right outputs
-            is_write_succeeded = self.sync_features(image_request_item, features)
+            is_write_succeeded = self.sink_features(image_request_item, features)
             if not is_write_succeeded:
                 raise AggregateOutputFeaturesException(
                     "Failed to write features to S3 or Kinesis! Please check the " "log..."
@@ -750,7 +750,7 @@ class ModelRunner:
     ) -> List[Feature]:
         """
         For a given image processing job - aggregate all the features that were collected for it and
-        put them in the correct output sync locations.
+        put them in the correct output sink locations.
 
         :param image_request_item: JobItem = the image request
         :param feature_table: FeatureTable = the table storing features from all completed regions
@@ -915,7 +915,7 @@ class ModelRunner:
 
     @staticmethod
     @metric_scope
-    def sync_features(image_request_item: JobItem, features: List[Feature], metrics: MetricsLogger = None) -> bool:
+    def sink_features(image_request_item: JobItem, features: List[Feature], metrics: MetricsLogger = None) -> bool:
         """
         Writing the features output to S3 and/or Kinesis Stream
 
@@ -923,7 +923,7 @@ class ModelRunner:
         :param features: List[Features] = the list of features to update
         :param metrics: the current metrics scope
 
-        :return: bool = if it has successfully written to an output sync
+        :return: bool = if it has successfully written to an output sink
         """
 
         if isinstance(metrics, MetricsLogger):


### PR DESCRIPTION
**Issue #, if available:** n/a

### Notes
In this context, a sink is the destination of a data flow (S3, Kinesis, etc.) so sync is incorrect and may cause confusion.

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
