### PR TITLE
feat: add variable overlap tiling strategy

### DIFF
--- a/src/aws/osml/model_runner/tile_worker/__init__.py
+++ b/src/aws/osml/model_runner/tile_worker/__init__.py
@@ -7,4 +7,5 @@
 from .tile_worker import TileWorker
 from .tile_worker_utils import process_tiles, setup_tile_workers
 from .tiling_strategy import TilingStrategy
+from .variable_overlap_tiling_strategy import VariableOverlapTilingStrategy
 from .variable_tile_tiling_strategy import VariableTileTilingStrategy

--- a/src/aws/osml/model_runner/tile_worker/variable_overlap_tiling_strategy.py
+++ b/src/aws/osml/model_runner/tile_worker/variable_overlap_tiling_strategy.py
@@ -1,0 +1,256 @@
+#  Copyright 2024 Amazon.com, Inc. or its affiliates.
+
+import logging
+from math import ceil, floor
+from typing import Dict, List, Tuple
+
+from geojson import Feature
+
+from ..common import ImageDimensions, ImageRegion, get_feature_image_bounds
+from ..inference import FeatureSelector
+from .tiling_strategy import TilingStrategy, ceildiv, generate_crops
+
+logger = logging.getLogger(__name__)
+
+
+class VariableOverlapTilingStrategy(TilingStrategy):
+    def compute_regions(
+        self,
+        processing_bounds: ImageRegion,
+        region_size: ImageDimensions,
+        tile_size: ImageDimensions,
+        overlap: ImageDimensions,
+    ) -> List[ImageRegion]:
+        """
+        Identify the regions that should be created from this image.
+
+        :param processing_bounds: the bounds of the full image or area of interest in pixels ((r, c), (w, h))
+        :param region_size: the size of the regions in pixels (w, h)
+        :param tile_size: the size of the tiles in pixels (w, y)
+        :param overlap: the amount of overlap (w, h)
+
+        :return: a collection of region boundaries
+        """
+        logger.debug(
+            "ENTER VariableOverlapTilingStrategy.compute_regions: "
+            f"{processing_bounds}, {region_size}, {tile_size}, {overlap}"
+        )
+
+        adjusted_overlap = self._calculate_overlap_for_full_tiles(processing_bounds[1], tile_size, overlap)
+        logger.debug(f"VariableOverlapTilingStrategy.compute_regions: adjusted_overlap = {adjusted_overlap}")
+
+        full_image_tiles = generate_crops(processing_bounds, tile_size, adjusted_overlap, only_full_tiles=True)
+        if full_image_tiles:
+            last_tile = full_image_tiles[-1]
+            adjusted_processing_bounds = (
+                processing_bounds[0],
+                (
+                    last_tile[0][1] + last_tile[1][0] - processing_bounds[0][1],
+                    last_tile[0][0] + last_tile[1][1] - processing_bounds[0][0],
+                ),
+            )
+            logger.debug(
+                f"VariableOverlapTilingStrategy.compute_regions: adjusted_processing_bounds = {adjusted_processing_bounds}"
+            )
+        else:
+            adjusted_processing_bounds = processing_bounds
+
+        adjusted_region_size = self._calculate_region_size_for_full_tiles(region_size, tile_size, adjusted_overlap)
+        logger.debug(f"VariableOverlapTilingStrategy.compute_regions: adjusted_region_size = {adjusted_region_size}")
+
+        return generate_crops(adjusted_processing_bounds, adjusted_region_size, adjusted_overlap)
+
+    def compute_tiles(self, region: ImageRegion, tile_size: ImageDimensions, overlap: ImageDimensions) -> List[ImageRegion]:
+        """
+        Identify the tiles that should be created from this region.
+
+        :param region: the bounds of the region in pixels ((r, c), (w, h))
+        :param tile_size: the size of the tiles in pixels (w, h)
+        :param overlap: the amount of overlap (w, h)
+
+        :return: a collection of tile boundaries
+        """
+        logger.debug(f"ENTER VariableOverlapTilingStrategy.compute_tiles: {region}, {tile_size}, {overlap}")
+
+        adjusted_overlap = self._calculate_overlap_for_full_tiles(region[1], tile_size, overlap)
+        logger.debug(f"VariableOverlapTilingStrategy.compute_tiles: adjusted_overlap = {adjusted_overlap}")
+
+        tiles = generate_crops(region, tile_size, adjusted_overlap, only_full_tiles=True)
+        if not tiles:
+            tiles = generate_crops(region, tile_size, adjusted_overlap, only_full_tiles=False)
+        return tiles
+
+    def cleanup_duplicate_features(
+        self,
+        processing_bounds: ImageRegion,
+        region_size: ImageDimensions,
+        tile_size: ImageDimensions,
+        overlap: ImageDimensions,
+        features: List[Feature],
+        feature_selector: FeatureSelector,
+    ) -> List[Feature]:
+        """
+        This method handles cleaning up duplicates caused by tiling by applying the feature selector to any features
+        that come from overlap regions.
+
+        :param processing_bounds: the bounds of the full image or area of interest in pixels ((r, c), (w, h))
+        :param region_size: the size of the regions in pixels (w, h)
+        :param tile_size: the size of the tiles in pixels (w, y)
+        :param overlap: the amount of overlap (w, h)
+        :param features: the collection of features to deduplicate
+        :param feature_selector: the algorithm that will be used to resolve duplicates
+
+        :return: the collection of features with duplicates removed
+        """
+
+        logger.debug(
+            f"ENTER VariableOverlapTilingStrategy.cleanup_duplicate_features: "
+            f"{processing_bounds}, {region_size}, {tile_size}, {overlap}"
+        )
+
+        adjusted_overlap = self._calculate_overlap_for_full_tiles(processing_bounds[1], tile_size, overlap)
+        logger.debug(f"VariableOverlapTilingStrategy.cleanup_duplicate_features: adjusted_overlap = {adjusted_overlap}")
+
+        adjusted_region_size = self._calculate_region_size_for_full_tiles(region_size, tile_size, adjusted_overlap)
+        logger.debug(
+            f"VariableOverlapTilingStrategy.cleanup_duplicate_features: adjusted_region_size = {adjusted_region_size}"
+        )
+
+        logger.debug(
+            "VariableOverlapTilingStrategy.cleanup_duplicate_features: Starting overlap-aware deduplication of features."
+        )
+        total_skipped = 0
+        deduped_features = []
+        features_grouped_by_region = self._group_features_by_overlap(features, adjusted_region_size, adjusted_overlap)
+        for region_key, region_features in features_grouped_by_region.items():
+            logger.debug(
+                "VariableOverlapTilingStrategy.cleanup_duplicate_features: "
+                f"Handling Region: {region_key} with {len(region_features)} features"
+            )
+
+            region_stride = (adjusted_region_size[0] - adjusted_overlap[0], adjusted_region_size[1] - adjusted_overlap[1])
+            region_origin = (region_stride[0] * region_key[0], region_stride[1] * region_key[2])
+
+            logger.debug(
+                "VariableOverlapTilingStrategy.cleanup_duplicate_features: "
+                f"Region Origin {region_origin} Region Stride {region_stride}"
+            )
+
+            if region_key[0] != region_key[1] or region_key[2] != region_key[3]:
+                # The Group contains contributions from multiple regions, run selection on the entire group
+                deduped_features.extend(feature_selector.select_features(region_features))
+            else:
+                # Not an overlap between regions group these features using tile size to identify overlaps
+                features_grouped_by_tile = self._group_features_by_overlap(
+                    region_features, tile_size, adjusted_overlap, region_origin
+                )
+
+                for tile_key, tile_features in features_grouped_by_tile.items():
+                    if tile_key[0] != tile_key[1] or tile_key[2] != tile_key[3]:
+                        # Group contains contributions from multiple tiles, run selection
+                        deduped_features.extend(feature_selector.select_features(tile_features))
+                    else:
+                        # No overlap between tiles, features can be added directly to the result
+                        total_skipped += len(tile_features)
+                        deduped_features.extend(tile_features)
+
+        logger.debug(
+            "VariableOverlapTilingStrategy.cleanup_duplicate_features: "
+            f"Skipped processing of {total_skipped} of {len(features)} features. "
+            "They were not inside an overlap region."
+        )
+
+        return deduped_features
+
+    @staticmethod
+    def _identify_overlap(
+        feature: Feature, shape: Tuple[int, int], overlap: Tuple[int, int], origin: Tuple[int, int] = (0, 0)
+    ) -> Tuple[int, int, int, int]:
+        """
+        Generate a tuple that contains the min and max indexes of adjacent tiles or regions for a given feature. If
+        the min and max values for both x and y are the same then this feature does not touch an overlap region.
+
+        :param feature: the geojson Feature that must contain properties to identify its location in an image
+        :param shape: the width, height of the area in pixels
+        :param overlap: the x, y overlap between areas in pixels
+        :param origin: the x, y coordinate of the area in relation to the full image
+
+        :return: a tuple: minx, maxx, miny, maxy that identifies any overlap.
+        """
+        bbox = get_feature_image_bounds(feature)
+
+        # If an offset origin was supplied adjust the bbox so the key is relative to the origin.
+        bbox = (bbox[0] - origin[0], bbox[1] - origin[1], bbox[2] - origin[0], bbox[3] - origin[1])
+
+        stride_x = shape[0] - overlap[0]
+        stride_y = shape[1] - overlap[1]
+
+        max_x_index = int(bbox[2] / stride_x)
+        max_y_index = int(bbox[3] / stride_y)
+
+        min_x_index = int(bbox[0] / stride_x)
+        min_y_index = int(bbox[1] / stride_y)
+        min_x_offset = int(bbox[0]) % stride_x
+        min_y_offset = int(bbox[1]) % stride_y
+
+        if min_x_offset < overlap[0] and min_x_index > 0:
+            min_x_index -= 1
+        if min_y_offset < overlap[1] and min_y_index > 0:
+            min_y_index -= 1
+
+        return min_x_index, max_x_index, min_y_index, max_y_index
+
+    @staticmethod
+    def _group_features_by_overlap(
+        features: List[Feature], shape: Tuple[int, int], overlap: Tuple[int, int], origin: Tuple[int, int] = (0, 0)
+    ) -> Dict[Tuple[int, int, int, int], List[Feature]]:
+        """
+        Group all the feature items by tile id
+
+        :param features: List[FeatureItem] = the list of feature items
+        :param shape: the width, height of the area in pixels
+        :param overlap: the x, y overlap between areas in pixels
+        :param origin: the x, y coordinate of the area in relation to the full image
+
+        :return: a mapping of overlap id to a list of features that intersect that overlap region
+        """
+        grouped_features: Dict[Tuple[int, int, int, int], List[Feature]] = {}
+        for feature in features:
+            overlap_key = VariableOverlapTilingStrategy._identify_overlap(feature, shape, overlap, origin)
+            grouped_features.setdefault(overlap_key, []).append(feature)
+        return grouped_features
+
+    @staticmethod
+    def _calculate_overlap_for_full_tiles(
+        full_image_size: ImageDimensions, fixed_tile_size: ImageDimensions, minimum_overlap: ImageDimensions
+    ) -> ImageDimensions:
+        def expand_overlap(image_dimension: int, tile_dimension: int, minimum_overlap: int) -> int:
+            stride = tile_dimension - minimum_overlap
+            num_tiles = ceildiv(image_dimension - minimum_overlap, stride)
+            if num_tiles > 1:
+                extra = minimum_overlap + num_tiles * stride - image_dimension
+                return minimum_overlap + ceil(extra / (num_tiles - 1))
+            else:
+                return minimum_overlap
+
+        return (
+            expand_overlap(full_image_size[0], fixed_tile_size[0], minimum_overlap[0]),
+            expand_overlap(full_image_size[1], fixed_tile_size[1], minimum_overlap[1]),
+        )
+
+    @staticmethod
+    def _calculate_region_size_for_full_tiles(
+        nominal_region_size: ImageDimensions, fixed_tile_size: ImageDimensions, minimum_overlap: ImageDimensions
+    ) -> ImageDimensions:
+        if minimum_overlap[0] >= fixed_tile_size[0] or minimum_overlap[1] >= fixed_tile_size[1]:
+            raise ValueError(f"Requested overlap {minimum_overlap} is invalid for tile size {fixed_tile_size}")
+
+        stride_x = fixed_tile_size[0] - minimum_overlap[0]
+        stride_y = fixed_tile_size[1] - minimum_overlap[1]
+        num_tiles_per_region_x = floor((nominal_region_size[0] - minimum_overlap[0]) / stride_x)
+        num_tiles_per_region_y = floor((nominal_region_size[1] - minimum_overlap[1]) / stride_y)
+
+        return (
+            stride_x * num_tiles_per_region_x + minimum_overlap[0],
+            stride_y * num_tiles_per_region_y + minimum_overlap[1],
+        )

--- a/test/aws/osml/model_runner/tile_worker/test_variable_overlap_tiling_strategy.py
+++ b/test/aws/osml/model_runner/tile_worker/test_variable_overlap_tiling_strategy.py
@@ -1,0 +1,170 @@
+#  Copyright 2024 Amazon.com, Inc. or its affiliates.
+
+from unittest import TestCase, main
+from unittest.mock import Mock
+
+
+class TestVariableOverlapTilingStrategy(TestCase):
+    def test_compute_regions_full_image(self):
+        from aws.osml.model_runner.tile_worker import VariableOverlapTilingStrategy
+
+        tiling_strategy = VariableOverlapTilingStrategy()
+
+        full_image_size = (25000, 12000)
+        nominal_region_size = (10000, 10000)
+        overlap = (100, 100)
+        tile_size = (4096, 4096)
+
+        # Check a full image
+        regions = tiling_strategy.compute_regions(((0, 0), full_image_size), nominal_region_size, tile_size, overlap)
+        assert len(regions) == 8
+        for r in regions:
+            assert r in [
+                ((0, 0), (7580, 8048)),
+                ((0, 6968), (7580, 8048)),
+                ((0, 13936), (7580, 8048)),
+                ((0, 20904), (4096, 8048)),
+                ((7904, 0), (7580, 4096)),
+                ((7904, 6968), (7580, 4096)),
+                ((7904, 13936), (7580, 4096)),
+                ((7904, 20904), (4096, 4096)),
+            ]
+
+    def test_compute_regions_roi(self):
+        from aws.osml.model_runner.tile_worker import VariableOverlapTilingStrategy
+
+        tiling_strategy = VariableOverlapTilingStrategy()
+
+        nominal_region_size = (10000, 10000)
+        overlap = (100, 100)
+        tile_size = (4096, 4096)
+
+        # Check regions generated from a subset of an image
+        regions = tiling_strategy.compute_regions(((200, 8000), (17000, 11800)), nominal_region_size, tile_size, overlap)
+        assert len(regions) == 6
+        for r in regions:
+            assert r in [
+                ((200, 8000), (7322, 7948)),
+                ((200, 14452), (7322, 7948)),
+                ((200, 20904), (4096, 7948)),
+                ((7904, 8000), (7322, 4096)),
+                ((7904, 14452), (7322, 4096)),
+                ((7904, 20904), (4096, 4096)),
+            ]
+
+    def test_compute_regions_tiny_image(self):
+        from aws.osml.model_runner.tile_worker import VariableOverlapTilingStrategy
+
+        tiling_strategy = VariableOverlapTilingStrategy()
+
+        nominal_region_size = (10000, 10000)
+        overlap = (100, 100)
+        tile_size = (4096, 4096)
+
+        # Check regions generated from an image that has a dimension smaller than the fixed tile size
+        regions = tiling_strategy.compute_regions(((0, 0), (12000, 2000)), nominal_region_size, tile_size, overlap)
+        assert len(regions) == 2
+        for r in regions:
+            assert r in [((0, 0), (8048, 2000)), ((0, 7904), (4096, 2000))]
+
+    def test_compute_tiles(self):
+        from aws.osml.model_runner.tile_worker import VariableOverlapTilingStrategy
+
+        tiling_strategy = VariableOverlapTilingStrategy()
+        overlap = (100, 100)
+        tile_size = (4096, 4096)
+
+        # First full region
+        tiles = tiling_strategy.compute_tiles(((0, 0), (7580, 8048)), tile_size, overlap)
+        assert len(tiles) == 4
+        for t in tiles:
+            assert t in [
+                ((0, 0), (4096, 4096)),
+                ((0, 3484), (4096, 4096)),
+                ((3952, 0), (4096, 4096)),
+                ((3952, 3484), (4096, 4096)),
+            ]
+
+        # A region on the right edge of the image
+        tiles = tiling_strategy.compute_tiles(((0, 20904), (4096, 8048)), tile_size, overlap)
+        assert len(tiles) == 2
+        for t in tiles:
+            assert t in [((0, 20904), (4096, 4096)), ((3952, 20904), (4096, 4096))]
+
+        # A region on the bottom edge of the image
+        tiles = tiling_strategy.compute_tiles(((7904, 13936), (7580, 4096)), tile_size, overlap)
+        assert len(tiles) == 2
+        for t in tiles:
+            assert t in [((7904, 13936), (4096, 4096)), ((7904, 17420), (4096, 4096))]
+
+        # The bottom right corner region
+        tiles = tiling_strategy.compute_tiles(((7904, 20904), (4096, 4096)), tile_size, overlap)
+        assert len(tiles) == 1
+        assert tiles[0] == ((7904, 20904), (4096, 4096))
+
+    def test_compute_tiles_tiny_region(self):
+        from aws.osml.model_runner.tile_worker import VariableOverlapTilingStrategy
+
+        tiling_strategy = VariableOverlapTilingStrategy()
+        overlap = (100, 100)
+        tile_size = (4096, 4096)
+
+        # If the requested region is smaller than the actual tile size then the full region
+        # will be turned into a single tile. This is an odd edge case that we don't expect
+        # to see much but we don't want to error out and will instead just fall back to
+        # a partial tile strategy.
+        tiles = tiling_strategy.compute_tiles(((10, 50), (1024, 2048)), tile_size, overlap)
+        assert len(tiles) == 1
+        assert tiles[0] == ((10, 50), (1024, 2048))
+
+    def test_deconflict_features(self):
+        from geojson import Feature
+
+        from aws.osml.model_runner.inference import FeatureSelector
+        from aws.osml.model_runner.tile_worker import VariableOverlapTilingStrategy
+
+        tiling_strategy = VariableOverlapTilingStrategy()
+
+        full_image_size = (25000, 12000)
+        full_image_region = ((0, 0), full_image_size)
+        nominal_region_size = (10000, 10000)
+        overlap = (100, 100)
+        tile_size = (4096, 4096)
+
+        features = [
+            # Duplicate features in overlap of two regions, keep 1
+            Feature(properties={"imageBBox": [20904, 7904, 20924, 7924]}),
+            Feature(properties={"imageBBox": [20905, 7905, 20925, 7925]}),
+            # Duplicate features in overlap of two tiles in lower edge region, keep 1
+            Feature(properties={"imageBBox": [17500, 10000, 17510, 10010]}),
+            Feature(properties={"imageBBox": [17500, 10000, 17510, 10010]}),
+            # Duplicate features in overlap of tiles in center of first region, keep 1
+            Feature(properties={"imageBBox": [4000, 4000, 4010, 4010]}),
+            Feature(properties={"imageBBox": [4000, 4000, 4010, 4010]}),
+            # Duplicate features in overlap of tiles in center of second region, keep 1
+            Feature(properties={"imageBBox": [10000, 4000, 10010, 4010]}),
+            Feature(properties={"imageBBox": [10000, 4000, 10010, 4010]}),
+            # Features duplicate but do not touch overlap regions, keep 2
+            Feature(properties={"imageBBox": [10, 10, 10, 10]}),
+            Feature(properties={"imageBBox": [10, 10, 10, 10]}),
+        ]
+
+        class DummyFeatureSelector(FeatureSelector):
+            def select_features(self, features):
+                if len(features) > 0:
+                    return [features[0]]
+                return []
+
+        mock_feature_selector = Mock(wraps=DummyFeatureSelector())
+        deduped_features = tiling_strategy.cleanup_duplicate_features(
+            full_image_region, nominal_region_size, tile_size, overlap, features, mock_feature_selector
+        )
+
+        # Check to ensure we have the correct number of features returned and that the feature selector
+        # was called once for each overlapping group
+        assert len(deduped_features) == 6
+        assert len(mock_feature_selector.method_calls) == 4
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR contains an implementation of the VariableOverlapTilingStrategy that has been requested by some users with CV models who need to receive full tiles of real pixels. This new region and tile decomposition strategy has been implemented using the new TilingStrategy abstraction which will allow us to easily enable this behavior with minimal code changes.

**Figure 1:** An example 25Kx12K image with 4096 tiles, a minimum of 100 pixel overlap and a 10K region size divided into regions using the baseline tiling strategy (VariableTileTilingStrategy). Note that the region size and overlap are fixed at the requested values but that tiles at the edges of each region and the image are truncated.
![image](https://github.com/user-attachments/assets/c0ca856c-c668-4397-ae52-9a93ec60fbda)

**Figure 2:** The same example image divided into regions using the new VariableOverlapTilingStrategy. Note that the overlap distance and region boundaries have been adjusted to make cutting full 4096x4096 tiles from each region possible.
![image](https://github.com/user-attachments/assets/02b585d5-92df-4db8-8241-03fdc067a985)


### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
