### PR TITLE
fix: use put_records for kinesis due to rate exceeded

### DIFF
--- a/src/aws/osml/model_runner/app_config.py
+++ b/src/aws/osml/model_runner/app_config.py
@@ -61,7 +61,9 @@ class ServiceConfig:
     throttling_retry_timeout: str = os.getenv("THROTTLING_RETRY_TIMEOUT", "10")
 
     # constant configuration
-    kinesis_max_record_size: str = "1048576"
+    kinesis_max_record_per_batch: str = "500"
+    kinesis_max_record_size_batch: str = "5242880"  # 5 MB in bytes
+    kinesis_max_record_size: str = "1048576"  # 1 MB in bytes
     ddb_max_item_size: str = "200000"
     noop_bounds_model_name: str = "NOOP_BOUNDS_MODEL_NAME"
     noop_geom_model_name: str = "NOOP_GEOM_MODEL_NAME"

--- a/src/aws/osml/model_runner/sink/kinesis_sink.py
+++ b/src/aws/osml/model_runner/sink/kinesis_sink.py
@@ -12,6 +12,7 @@ from aws.osml.model_runner.api import SinkMode, SinkType
 from aws.osml.model_runner.app_config import BotoConfig, ServiceConfig
 from aws.osml.model_runner.common import get_credentials_for_assumed_role
 
+from .exceptions import InvalidKinesisStreamException
 from .sink import Sink
 
 logger = logging.getLogger(__name__)
@@ -41,13 +42,16 @@ class KinesisSink(Sink):
             # container will be sufficient to write to the Kinesis stream.
             self.kinesis_client = boto3.client("kinesis", config=BotoConfig.default)
 
-    def _flush_stream(self, partition_key: str, features: List[Feature]) -> None:
-        record = geojson.dumps(FeatureCollection(features))
-        self.kinesis_client.put_record(
-            StreamName=self.stream,
-            PartitionKey=partition_key,
-            Data=record,
-        )
+    def _flush_stream(self, records: List[dict]) -> None:
+        """
+        Flushes a batch of records to the Kinesis stream.
+
+        :param records: A list of records to be sent to the Kinesis stream.
+        """
+        try:
+            self.kinesis_client.put_records(StreamName=self.stream, Records=records)
+        except Exception as err:
+            raise InvalidKinesisStreamException(f"Failed to write records to Kinesis stream '{self.stream}': {err}")
 
     @property
     def mode(self) -> SinkMode:
@@ -55,28 +59,44 @@ class KinesisSink(Sink):
         return SinkMode.AGGREGATE
 
     def write(self, job_id: str, features: List[Feature]) -> bool:
-        pending_features: List[Feature] = []
+        """
+        Writes a list of features to the Kinesis stream. Each feature is serialized and sent
+        as a record. If the batch of records exceeds the 5 MB limit, the current batch is flushed.
+
+        :param job_id: The ID of the job associated with the features.
+        :param features: A list of features to be written to the stream.
+
+        :returns: True if the features were successfully written, False otherwise.
+        """
+        pending_features: List[dict] = []
         pending_features_size: int = 0
 
         if self.validate_kinesis_stream():
             for feature in features:
-                if self.batch_size == 1:
-                    self._flush_stream(job_id, [feature])
-                else:
-                    feature_size = sys.getsizeof(geojson.dumps(feature))
-                    if (
-                        self.batch_size and pending_features and len(pending_features) % self.batch_size == 0
-                    ) or pending_features_size + feature_size > (int(ServiceConfig.kinesis_max_record_size)):
-                        self._flush_stream(job_id, pending_features)
-                        pending_features = []
-                        pending_features_size = 0
+                # Serialize feature data to JSON
+                record_data = geojson.dumps(FeatureCollection(feature))
 
-                    pending_features.append(feature)
-                    pending_features_size += feature_size
+                # Create the record dict
+                record = {"Data": record_data, "PartitionKey": job_id}
 
-            # Flush any remaining features
+                # Calculate size of the entire record (Data + PartitionKey)
+                record_size = sys.getsizeof(geojson.dumps(record))
+
+                # If adding the next record would exceed the 5 MB batch limit, flush the current batch
+                if pending_features_size + record_size > int(ServiceConfig.kinesis_max_record_size_batch) or len(
+                    pending_features
+                ) >= int(ServiceConfig.kinesis_max_record_per_batch):
+                    self._flush_stream(pending_features)
+                    pending_features = []
+                    pending_features_size = 0
+
+                pending_features.append(record)
+                pending_features_size += record_size
+
+            # Flush any remaining records
             if pending_features:
-                self._flush_stream(job_id, pending_features)
+                self._flush_stream(pending_features)
+
             logger.info(f"Wrote {len(features)} features for job '{job_id}' to Kinesis Stream '{self.stream}'")
             return True
         else:


### PR DESCRIPTION
**Issue #, if available:** n/a

### Notes

This pull request enhances the KinesisSink class by updating the `_flush_stream` method to improve the handling of records sent to the Kinesis stream. The changes ensure compliance with Kinesis limits, specifically allowing a maximum of 500 records per request, while the total request size does not exceed 5 MB.

**Ran the load test for an hour:**

| Metric                       | Before PR               | This PR               |
|------------------------------|-------------------------|-------------------------|
| Total Images Sent            | 112                     | 115                     |
| Total Images In-Progress     | 14                      | 2                       |
| Total Images Processed       | 98                      | 113                     |
| Total Images Succeeded       | 91                      | 113                     |
| Total Images Failed          | 7                       | 0                       |
| Total GB Processed           | 18.63                   | 30.55                   |
| Total Pixels Processed       | 6,667,674,894           | 10,933,475,922          |

The above load test uses a variety of rareplane images of different sizes (ranging from small to large) and runs for one hour, sending an image request every 30 seconds.

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
