### PR TITLE
fix: feature selection error for zero area features

### DIFF
--- a/src/aws/osml/model_runner/inference/feature_selection.py
+++ b/src/aws/osml/model_runner/inference/feature_selection.py
@@ -82,6 +82,22 @@ class FeatureSelector:
         for feature in feature_list:
             # [min_x, min_y, max_x, max_y]
             bounds_imcoords = get_feature_image_bounds(feature)
+
+            # This is a workaround for assumptions made by the NMS library and normalization code in this class.
+            # All of that code assumes that features have bounding boxes with a non-zero area. That assumption
+            # does not hold for features reported as a single point geometry or others that might simply be
+            # erroneously reported with a zero width or height bbox. No matter the cause, we would like those
+            # features to pass through our feature selection processing without triggering errors. Here we
+            # add 0.1 of a pixel to the width or height of any bbox if it is currently zero. This does not change
+            # the actual reported geometry of the feature in any way it just ensures the assumption of a non-zero
+            # area is true.
+            bounds_imcoords = (
+                bounds_imcoords[0],
+                bounds_imcoords[1],
+                bounds_imcoords[2] + 0.1 if bounds_imcoords[0] == bounds_imcoords[2] else bounds_imcoords[2],
+                bounds_imcoords[3] + 0.1 if bounds_imcoords[1] == bounds_imcoords[3] else bounds_imcoords[3],
+            )
+
             category, score = self._get_category_and_score_from_feature(feature)
             boxes.append(bounds_imcoords)
             categories.append(category)

--- a/test/aws/osml/model_runner/inference/test_feature_selection.py
+++ b/test/aws/osml/model_runner/inference/test_feature_selection.py
@@ -192,6 +192,26 @@ class TestFeatureSelection(TestCase):
         processed_features = feature_selector.select_features(original_features)
         assert len(processed_features) == 3
 
+    def test_feature_selection_nms_point_feature(self):
+        from aws.osml.model_runner.common import FeatureDistillationNMS
+        from aws.osml.model_runner.inference import FeatureSelector
+
+        feature_selection_option = FeatureDistillationNMS()
+        feature_selector = FeatureSelector(options=feature_selection_option)
+
+        test_feature = [
+            Feature(
+                geometry=Point((85.000111, 32.983222, 0.0)),
+                id="point-feature",
+                properties={
+                    "bounds_imcoords": [409.6, 409.6, 409.6, 409.6],
+                    "featureClasses": [{"iri": "boat", "score": 0.85}],
+                },
+            )
+        ]
+        processed_features = feature_selector.select_features(test_feature)
+        assert len(processed_features) == 1
+
     def test_feature_selection_soft_nms_overlaps(self):
         from aws.osml.model_runner.common import FeatureDistillationSoftNMS
         from aws.osml.model_runner.inference import FeatureSelector


### PR DESCRIPTION
This change avoids errors in the feature selection processing triggered by features that have a zero area bounding box. Those cases can happen for ML detections reported as a single point or for detections that were erroneously reported with a zero width or height bounding box. 

This problem originally manifested as a divide by zero error in the feature selection normalization process but if that is fixed directly it exposed other error paths through the 3rd party ensemble-boxes library. Instead of working around each of those issues independently it was more robust to enforce the non-zero area assumption made by this code by adding a small (0.1 pixel) buffer to the bbox width or height if it is zero. This allows point features to flow through the normal feature selection process along side other features without error. 

Note that this additional padding is only applied to the temporary variables used and then discarded by the feature selection code. It does not modify the actual reported detection geometry in any way. 

A new test case has been added that demonstrated the original divide by zero error (and some additional errors in the NMS processing). That test case now passes with these updates.

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
