### PR TITLE
fix: remove noop model logic

### DIFF
--- a/src/aws/osml/model_runner/app_config.py
+++ b/src/aws/osml/model_runner/app_config.py
@@ -65,8 +65,6 @@ class ServiceConfig:
     kinesis_max_record_size_batch: str = "5242880"  # 5 MB in bytes
     kinesis_max_record_size: str = "1048576"  # 1 MB in bytes
     ddb_max_item_size: str = "200000"
-    noop_bounds_model_name: str = "NOOP_BOUNDS_MODEL_NAME"
-    noop_geom_model_name: str = "NOOP_GEOM_MODEL_NAME"
 
 
 @dataclass

--- a/src/aws/osml/model_runner/tile_worker/tile_worker.py
+++ b/src/aws/osml/model_runner/tile_worker/tile_worker.py
@@ -108,7 +108,7 @@ class TileWorker(Thread):
                 )
         except Exception as e:
             self.failed_tile_count += 1
-            logging.error(f"Failed to process region tile with error: {e.with_traceback()}")
+            logging.error(f"Failed to process region tile with error: {e}", exc_info=True)
             self.region_request_table.add_tile(
                 image_info.get("image_id"), image_info.get("region_id"), image_info.get("region"), TileState.FAILED
             )

--- a/test/aws/osml/model_runner/inference/test_feature_utils.py
+++ b/test/aws/osml/model_runner/inference/test_feature_utils.py
@@ -8,6 +8,11 @@ import geojson
 import numpy as np
 import pytest
 import shapely
+from osgeo import gdal
+
+# GDAL 4.0 will begin using exceptions as the default; at this point the software is written to assume
+# no exceptions so we call this explicitly until the software can be updated to match.
+gdal.DontUseExceptions()
 
 
 class TestFeatureUtils(unittest.TestCase):
@@ -100,12 +105,13 @@ class TestFeatureUtils(unittest.TestCase):
         chip_lr = sensor_model.image_to_world(ImageCoordinate([101, 101]))
         min_vals = np.minimum(chip_ul.coordinate, chip_lr.coordinate)
         max_vals = np.maximum(chip_ul.coordinate, chip_lr.coordinate)
-        polygon_coords = []
-        polygon_coords.append([degrees(min_vals[0]), degrees(min_vals[1])])
-        polygon_coords.append([degrees(min_vals[0]), degrees(max_vals[1])])
-        polygon_coords.append([degrees(max_vals[0]), degrees(max_vals[1])])
-        polygon_coords.append([degrees(max_vals[0]), degrees(min_vals[1])])
-        polygon_coords.append([degrees(min_vals[0]), degrees(min_vals[1])])
+        polygon_coords = [
+            [degrees(min_vals[0]), degrees(min_vals[1])],
+            [degrees(min_vals[0]), degrees(max_vals[1])],
+            [degrees(max_vals[0]), degrees(max_vals[1])],
+            [degrees(max_vals[0]), degrees(min_vals[1])],
+            [degrees(min_vals[0]), degrees(min_vals[1])],
+        ]
         roi = shapely.geometry.Polygon(polygon_coords)
 
         processing_bounds = calculate_processing_bounds(ds, roi, sensor_model)
@@ -122,12 +128,13 @@ class TestFeatureUtils(unittest.TestCase):
         chip_lr = sensor_model.image_to_world(ImageCoordinate([50, 50]))
         min_vals = np.minimum(chip_ul.coordinate, chip_lr.coordinate)
         max_vals = np.maximum(chip_ul.coordinate, chip_lr.coordinate)
-        polygon_coords = []
-        polygon_coords.append([degrees(min_vals[0]), degrees(min_vals[1])])
-        polygon_coords.append([degrees(min_vals[0]), degrees(max_vals[1])])
-        polygon_coords.append([degrees(max_vals[0]), degrees(max_vals[1])])
-        polygon_coords.append([degrees(max_vals[0]), degrees(min_vals[1])])
-        polygon_coords.append([degrees(min_vals[0]), degrees(min_vals[1])])
+        polygon_coords = [
+            [degrees(min_vals[0]), degrees(min_vals[1])],
+            [degrees(min_vals[0]), degrees(max_vals[1])],
+            [degrees(max_vals[0]), degrees(max_vals[1])],
+            [degrees(max_vals[0]), degrees(min_vals[1])],
+            [degrees(min_vals[0]), degrees(min_vals[1])],
+        ]
         roi = shapely.geometry.Polygon(polygon_coords)
 
         processing_bounds = calculate_processing_bounds(ds, roi, sensor_model)

--- a/test/aws/osml/model_runner/inference/test_sm_detector.py
+++ b/test/aws/osml/model_runner/inference/test_sm_detector.py
@@ -12,7 +12,7 @@ import pytest
 from botocore.exceptions import ClientError
 from botocore.stub import ANY, Stubber
 
-MOCK_RESPONSE = {
+MOCK_MODEL_RESPONSE = {
     "Body": io.StringIO(
         json.dumps(
             {
@@ -21,12 +21,13 @@ MOCK_RESPONSE = {
                     {
                         "type": "Feature",
                         "id": "1cc5e6d6-e12f-430d-adf0-8d2276ce8c5a",
-                        "geometry": {"type": "Point", "coordinates": [0.0, 0.0]},
+                        "geometry": {"type": "Point", "coordinates": [-43.679691, -22.941953]},
                         "properties": {
                             "bounds_imcoords": [429, 553, 440, 561],
-                            "feature_types": {"ground_motor_passenger_vehicle": 0.2961518168449402},
+                            "geom_imcoords": [[429, 553], [429, 561], [440, 561], [440, 553], [429, 553]],
+                            "featureClasses": [{"iri": "ground_motor_passenger_vehicle", "score": 0.2961518168449402}],
                             "detection_score": 0.2961518168449402,
-                            "image_id": "test-image-id",
+                            "image_id": "2pp5e6d6-e12f-430d-adf0-8d2276ceadf0",
                         },
                     }
                 ],
@@ -68,7 +69,7 @@ class TestSMDetector(TestCase):
         sm_runtime_stub.add_response(
             "invoke_endpoint",
             expected_params={"EndpointName": "test-endpoint", "Body": ANY},
-            service_response=MOCK_RESPONSE,
+            service_response=MOCK_MODEL_RESPONSE,
         )
         sm_runtime_stub.activate()
 
@@ -87,7 +88,7 @@ class TestSMDetector(TestCase):
         sm_runtime_stub.add_response(
             "invoke_endpoint",
             expected_params={"EndpointName": "test-endpoint", "Body": ANY},
-            service_response=MOCK_RESPONSE,
+            service_response=MOCK_MODEL_RESPONSE,
         )
         sm_runtime_stub.add_client_error(str(JSONDecodeError))
         sm_runtime_stub.activate()
@@ -106,7 +107,7 @@ class TestSMDetector(TestCase):
         sm_client_stub.add_response(
             "invoke_endpoint",
             expected_params={"EndpointName": "test-endpoint", "Body": ANY},
-            service_response=MOCK_RESPONSE,
+            service_response=MOCK_MODEL_RESPONSE,
         )
         sm_client_stub.add_client_error(str(ClientError({"Error": {"Code": 500, "Message": "ClientError"}}, "update_item")))
         feature_detector.sm_client.invoke_endpoint = Mock(

--- a/test/aws/osml/model_runner/status/test_image_status_monitor.py
+++ b/test/aws/osml/model_runner/status/test_image_status_monitor.py
@@ -2,7 +2,6 @@
 
 import os
 import unittest
-from decimal import Decimal
 
 import boto3
 from moto import mock_aws
@@ -29,10 +28,10 @@ class TestImageStatusMonitor(unittest.TestCase):
         self.test_job_item = JobItem(
             job_id="test-job",
             image_id="test-image",
-            processing_duration=Decimal(1000),
-            region_success=Decimal(5),
-            region_error=Decimal(0),
-            region_count=Decimal(5),
+            processing_duration=1000,
+            region_success=5,
+            region_error=0,
+            region_count=5,
         )
 
     def test_process_event_success(self):
@@ -56,9 +55,9 @@ class TestImageStatusMonitor(unittest.TestCase):
             job_id=None,
             image_id="test-image",
             processing_duration=None,
-            region_success=Decimal(0),
-            region_error=Decimal(5),
-            region_count=Decimal(5),
+            region_success=0,
+            region_error=5,
+            region_count=5,
         )
         status = RequestStatus.FAILED
         message = "Processing failed."

--- a/test/aws/osml/model_runner/status/test_region_status_monitor.py
+++ b/test/aws/osml/model_runner/status/test_region_status_monitor.py
@@ -2,7 +2,6 @@
 
 import os
 import unittest
-from decimal import Decimal
 
 import boto3
 from moto import mock_aws
@@ -30,12 +29,12 @@ class TestRegionStatusMonitor(unittest.TestCase):
             job_id="test-job",
             image_id="test-image",
             region_id="test-region",
-            processing_duration=Decimal(1000),
-            failed_tile_count=Decimal(0),
+            processing_duration=1000,
+            failed_tile_count=0,
             failed_tiles=[],
-            succeeded_tile_count=Decimal(0),
+            succeeded_tile_count=0,
             succeeded_tiles=[],
-            total_tiles=Decimal(10),
+            total_tiles=10,
         )
 
     def test_process_event_success(self):
@@ -61,7 +60,7 @@ class TestRegionStatusMonitor(unittest.TestCase):
             region_id="test-region",
             processing_duration=None,  # Required field
             failed_tiles=[],
-            total_tiles=Decimal(10),
+            total_tiles=10,
         )
         status = RequestStatus.FAILED
         message = "Processing failed."

--- a/test/configuration.py
+++ b/test/configuration.py
@@ -1,68 +1,80 @@
 #  Copyright 2023-2024 Amazon.com, Inc. or its affiliates.
+import io
+import json
+from unittest.mock import Mock
 
-# Environment Variable Configuration
-TEST_ENV_CONFIG = {
-    # ModelRunner test config
-    "AWS_DEFAULT_REGION": "us-west-2",
-    "WORKERS": "4",
-    "WORKERS_PER_CPU": "1",
-    "JOB_TABLE": "TEST-JOB-TABLE",
-    "ENDPOINT_TABLE": "TEST-ENDPOINT-STATS-TABLE",
-    "FEATURE_TABLE": "TEST-FEATURE-TABLE",
-    "REGION_REQUEST_TABLE": "TEST-REGION-REQUEST-TABLE",
-    "IMAGE_QUEUE": "TEST-IMAGE-QUEUE",
-    "REGION_QUEUE": "TEST-REGION-QUEUE",
-    "IMAGE_STATUS_TOPIC": "TEST-IMAGE-STATUS-TOPIC",
-    "REGION_STATUS_TOPIC": "TEST-REGION-STATUS-TOPIC",
-    # Fake cred info for MOTO
-    "AWS_ACCESS_KEY_ID": "testing",
-    "AWS_SECRET_ACCESS_KEY": "testing",
-    "AWS_SECURITY_TOKEN": "testing",
-    "AWS_SESSION_TOKEN": "testing",
-    "SM_SELF_THROTTLING": "true",
+from botocore.exceptions import ClientError
+
+MOCK_MODEL_RESPONSE = {
+    "Body": io.StringIO(
+        json.dumps(
+            {
+                "type": "FeatureCollection",
+                "features": [
+                    {
+                        "type": "Feature",
+                        "id": "1cc5e6d6-e12f-430d-adf0-8d2276ce8c5a",
+                        "geometry": {"type": "Point", "coordinates": [-43.679691, -22.941953]},
+                        "properties": {
+                            "bounds_imcoords": [429, 553, 440, 561],
+                            "geom_imcoords": [[429, 553], [429, 561], [440, 561], [440, 553], [429, 553]],
+                            "featureClasses": [{"iri": "ground_motor_passenger_vehicle", "score": 0.2961518168449402}],
+                            "detection_score": 0.2961518168449402,
+                            "image_id": "2pp5e6d6-e12f-430d-adf0-8d2276ceadf0",
+                        },
+                    }
+                ],
+            }
+        )
+    )
 }
-# Fake account ID
-TEST_ACCOUNT = "123456789123"
 
-# DDB Configurations
-TEST_JOB_TABLE_KEY_SCHEMA = [{"AttributeName": "image_id", "KeyType": "HASH"}]
-TEST_JOB_TABLE_ATTRIBUTE_DEFINITIONS = [{"AttributeName": "image_id", "AttributeType": "S"}]
 
-TEST_ENDPOINT_TABLE_KEY_SCHEMA = [{"AttributeName": "endpoint", "KeyType": "HASH"}]
-TEST_ENDPOINT_TABLE_ATTRIBUTE_DEFINITIONS = [
-    {"AttributeName": "endpoint", "AttributeType": "S"},
-]
-
-TEST_FEATURE_TABLE_KEY_SCHEMA = [
-    {"AttributeName": "hash_key", "KeyType": "HASH"},
-    {"AttributeName": "range_key", "KeyType": "RANGE"},
-]
-TEST_FEATURE_TABLE_ATTRIBUTE_DEFINITIONS = [
-    {"AttributeName": "hash_key", "AttributeType": "S"},
-    {"AttributeName": "range_key", "AttributeType": "S"},
-]
-
-TEST_REGION_REQUEST_TABLE_KEY_SCHEMA = [
-    {"AttributeName": "region_id", "KeyType": "HASH"},
-    {"AttributeName": "image_id", "KeyType": "RANGE"},
-]
-TEST_REGION_REQUEST_TABLE_ATTRIBUTE_DEFINITIONS = [
-    {"AttributeName": "region_id", "AttributeType": "S"},
-    {"AttributeName": "image_id", "AttributeType": "S"},
-]
-
-# S3 Configurations
-TEST_RESULTS_BUCKET = "test-results-bucket"
-TEST_IMAGE_FILE = "./test/data/small.ntf"
-TEST_IMAGE_BUCKET = "test-image-bucket"
-TEST_IMAGE_KEY = "small.ntf"
-TEST_S3_FULL_BUCKET_PATH = "s3://test-results-bucket/test/data/small.ntf"
-
-TEST_RESULTS_STREAM = "test-results-stream"
-
-TEST_IMAGE_ID = "test-image-id"
-TEST_IMAGE_EXTENSION = "NITF"
-TEST_JOB_ID = "test-job-id"
-TEST_REGION_ID = "test-region-id"
-
-TEST_ELEVATION_DATA_LOCATION = "s3://TEST-BUCKET/ELEVATION-DATA-LOCATION"
+TEST_CONFIG = {
+    "ACCOUNT_ID": "123456789123",
+    "ELEVATION_DATA_LOCATION": "s3://test-bucket/elevation-data",
+    "ENDPOINT_PRODUCTION_VARIANTS": [
+        {"VariantName": "Primary", "ModelName": "TestModel", "InitialInstanceCount": 1, "InstanceType": "ml.m5.12xlarge"}
+    ],
+    "ENDPOINT_TABLE_ATTRIBUTE_DEFINITIONS": [{"AttributeName": "endpoint", "AttributeType": "S"}],
+    "ENDPOINT_TABLE_KEY_SCHEMA": [{"AttributeName": "endpoint", "KeyType": "HASH"}],
+    "FEATURE_TABLE_ATTRIBUTE_DEFINITIONS": [
+        {"AttributeName": "hash_key", "AttributeType": "S"},
+        {"AttributeName": "range_key", "AttributeType": "S"},
+    ],
+    "FEATURE_TABLE_KEY_SCHEMA": [
+        {"AttributeName": "hash_key", "KeyType": "HASH"},
+        {"AttributeName": "range_key", "KeyType": "RANGE"},
+    ],
+    "IMAGE_BUCKET": "test-image-bucket",
+    "IMAGE_EXTENSION": "NITF",
+    "IMAGE_FILE": "./test/data/small.ntf",
+    "IMAGE_ID": "test-image-id",
+    "IMAGE_KEY": "small.ntf",
+    "JOB_ID": "test-job-id",
+    "JOB_NAME": "test-job-name",
+    "JOB_TABLE_ATTRIBUTE_DEFINITIONS": [{"AttributeName": "image_id", "AttributeType": "S"}],
+    "JOB_TABLE_KEY_SCHEMA": [{"AttributeName": "image_id", "KeyType": "HASH"}],
+    "MOCK_PUT_EXCEPTION": Mock(side_effect=ClientError({"Error": {"Code": 500, "Message": "ClientError"}}, "put_item")),
+    "MOCK_UPDATE_EXCEPTION": Mock(
+        side_effect=ClientError({"Error": {"Code": 500, "Message": "ClientError"}}, "update_item")
+    ),
+    "MODEL_ENDPOINT": "TestEndpoint",
+    "MODEL_NAME": "TestModel",
+    "REGION_ID": "test-region-id",
+    "REGION_REQUEST_TABLE_ATTRIBUTE_DEFINITIONS": [
+        {"AttributeName": "region_id", "AttributeType": "S"},
+        {"AttributeName": "image_id", "AttributeType": "S"},
+    ],
+    "REGION_REQUEST_TABLE_KEY_SCHEMA": [
+        {"AttributeName": "region_id", "KeyType": "HASH"},
+        {"AttributeName": "image_id", "KeyType": "RANGE"},
+    ],
+    "RESULTS_BUCKET": "test-results-bucket",
+    "RESULTS_STREAM": "test-results-stream",
+    "S3_FULL_BUCKET_PATH": "s3://test-results-bucket/test/data/small.ntf",
+    "SM_MODEL_CONTAINER": {
+        "Image": "123456789123.dkr.ecr.us-east-1.amazonaws.com/test:1",
+        "ModelDataUrl": "s3://test-bucket/model.tar.gz",
+    },
+}


### PR DESCRIPTION
**Issue #, if available:** n/a

### Notes
This PR replaces the real `find_features` method of the `SMDetector` class with a mocked version of (`invoke_endpoint`) called by the SageMaker client during testing, simulating a GeoJSON response from a SageMaker model without real endpoint invocations. Removing any logic for supporting NOOP models in the find features methods in the associated Detection classes.

#### Key Changes:
1. **Mocking `find_features`:**
   - Added `mock_find_features` to simulate model inference, returning a GeoJSON `FeatureCollection`.
   - Patched `find_features` in `SMDetector` using `unittest.mock.patch.object` to use the mock in tests.

2. **Updated Unit Test (`test_process_bounds_image_request`):**
   - Integrated `mock_find_features` into the `SMDetector` instance for controlled testing.
   - Retained `Stubber` to simulate the SageMaker client response for `invoke_endpoint`.

#### Benefits:
- Improved test coverage and reliability for feature detection logic.

#### Testing:
- All unit tests, including the modified test, passed.
- Manual validation confirmed correct integration and output format.

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
