### PR TITLE
refactor: copy ensemble_boxes_nms from ensemble_boxes package

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -17,4 +17,4 @@ partial_branches =
 
 show_missing = True
 
-fail_under = 88
+fail_under = 87

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,10 +55,10 @@ install_requires =
     scipy==1.12.0;python_version>='3.11'
     argparse==1.4.0
     dacite==1.8.1
-    ensemble-boxes==1.0.9
     codeguru-profiler-agent==1.2.4
     defusedxml>=0.7.1
     requests==2.31.0
+    numba>=0.60.0
 
 [options.packages.find]
 where = src

--- a/src/aws/osml/model_runner/common/__init__.py
+++ b/src/aws/osml/model_runner/common/__init__.py
@@ -7,6 +7,7 @@
 from .auto_string_enum import AutoStringEnum
 from .credentials_utils import get_credentials_for_assumed_role
 from .endpoint_utils import EndpointUtils
+from .ensemble_boxes_nms import nms, nms_method, prepare_boxes, soft_nms
 from .exceptions import InvalidAssumedRoleException
 from .feature_utils import get_feature_image_bounds
 from .log_context import ThreadingLocalContextFilter

--- a/src/aws/osml/model_runner/common/ensemble_boxes_nms.py
+++ b/src/aws/osml/model_runner/common/ensemble_boxes_nms.py
@@ -1,0 +1,318 @@
+#  Copyright 2024 Amazon.com, Inc. or its affiliates.
+
+"""
+This file contains code for performing non-maximum suppression (NMS) on bounding boxes obtained from multiple object detection models. The code was originally taken from the following GitHub repository:
+
+https://github.com/ZFTurbo/Weighted-Boxes-Fusion/blob/master/ensemble_boxes/ensemble_boxes_nms.py
+
+The original author is 'ZFTurbo' (https://kaggle.com/zfturbo).
+
+This implementation provides functions for standard NMS, linear soft-NMS, and gaussian soft-NMS. It also includes a method for preparing the boxes, scores, and labels before applying NMS.
+"""
+
+from typing import List, Optional, Tuple
+
+import numpy as np
+from numba import jit
+
+
+def prepare_boxes(boxes: np.ndarray, scores: np.ndarray, labels: np.ndarray) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """
+    Prepare boxes by correcting invalid coordinates and removing boxes with zero area.
+
+    :param boxes: Array of shape (N, 4) with box coordinates in the format [x1, y1, x2, y2], where all values are normalized [0, 1].
+    :param scores: Array of shape (N,) with confidence scores for each box.
+    :param labels: Array of shape (N,) with labels for each box.
+
+    :return: Tuple containing the filtered and corrected boxes, scores, and labels.
+    """
+    result_boxes = boxes.copy()
+
+    cond = result_boxes < 0
+    cond_sum = cond.astype(np.int32).sum()
+    if cond_sum > 0:
+        print("Warning. Fixed {} boxes coordinates < 0".format(cond_sum))
+        result_boxes[cond] = 0
+
+    cond = result_boxes > 1
+    cond_sum = cond.astype(np.int32).sum()
+    if cond_sum > 0:
+        print("Warning. Fixed {} boxes coordinates > 1. Check that your boxes was normalized at [0, 1]".format(cond_sum))
+        result_boxes[cond] = 1
+
+    boxes1 = result_boxes.copy()
+    result_boxes[:, 0] = np.min(boxes1[:, [0, 2]], axis=1)
+    result_boxes[:, 2] = np.max(boxes1[:, [0, 2]], axis=1)
+    result_boxes[:, 1] = np.min(boxes1[:, [1, 3]], axis=1)
+    result_boxes[:, 3] = np.max(boxes1[:, [1, 3]], axis=1)
+
+    area = (result_boxes[:, 2] - result_boxes[:, 0]) * (result_boxes[:, 3] - result_boxes[:, 1])
+    cond = area == 0
+    cond_sum = cond.astype(np.int32).sum()
+    if cond_sum > 0:
+        print("Warning. Removed {} boxes with zero area!".format(cond_sum))
+        result_boxes = result_boxes[area > 0]
+        scores = scores[area > 0]
+        labels = labels[area > 0]
+
+    return result_boxes, scores, labels
+
+
+def cpu_soft_nms_float(dets: np.ndarray, sc: np.ndarray, Nt: float, sigma: float, thresh: float, method: int) -> np.ndarray:
+    """
+    Based on: https://github.com/DocF/Soft-NMS/blob/master/soft_nms.py
+    It's different from original soft-NMS because we have float coordinates on range [0; 1]
+
+    :param dets: boxes format [x1, y1, x2, y2]
+    :param sc: scores for boxes
+    :param Nt: required iou
+    :param sigma: Sigma value for Gaussian soft-NMS.
+    :param thresh: Score threshold to filter boxes.
+    :param method: 1 - linear soft-NMS, 2 - gaussian soft-NMS, 3 - standard NMS
+
+    :return: index of boxes to keep
+    """
+
+    # indexes concatenate boxes with the last column
+    N = dets.shape[0]
+    indexes = np.array([np.arange(N)])
+    dets = np.concatenate((dets, indexes.T), axis=1)
+
+    # the order of boxes coordinate is [y1, x1, y2, x2]
+    y1 = dets[:, 1]
+    x1 = dets[:, 0]
+    y2 = dets[:, 3]
+    x2 = dets[:, 2]
+    scores = sc
+    areas = (x2 - x1) * (y2 - y1)
+
+    for i in range(N):
+        # intermediate parameters for later parameters exchange
+        tBD = dets[i, :].copy()
+        tscore = scores[i].copy()
+        tarea = areas[i].copy()
+        pos = i + 1
+
+        #
+        if i != N - 1:
+            maxscore = np.max(scores[pos:], axis=0)
+            maxpos = np.argmax(scores[pos:], axis=0)
+        else:
+            maxscore = scores[-1]
+            maxpos = 0
+        if tscore < maxscore:
+            dets[i, :] = dets[maxpos + i + 1, :]
+            dets[maxpos + i + 1, :] = tBD
+            tBD = dets[i, :]
+
+            scores[i] = scores[maxpos + i + 1]
+            scores[maxpos + i + 1] = tscore
+            tscore = scores[i]
+
+            areas[i] = areas[maxpos + i + 1]
+            areas[maxpos + i + 1] = tarea
+            tarea = areas[i]
+
+        # IoU calculate
+        xx1 = np.maximum(dets[i, 1], dets[pos:, 1])
+        yy1 = np.maximum(dets[i, 0], dets[pos:, 0])
+        xx2 = np.minimum(dets[i, 3], dets[pos:, 3])
+        yy2 = np.minimum(dets[i, 2], dets[pos:, 2])
+
+        w = np.maximum(0.0, xx2 - xx1)
+        h = np.maximum(0.0, yy2 - yy1)
+        inter = w * h
+        ovr = inter / (areas[i] + areas[pos:] - inter)
+
+        # Three methods: 1.linear 2.gaussian 3.original NMS
+        if method == 1:  # linear
+            weight = np.ones(ovr.shape)
+            weight[ovr > Nt] = weight[ovr > Nt] - ovr[ovr > Nt]
+        elif method == 2:  # gaussian
+            weight = np.exp(-(ovr * ovr) / sigma)
+        else:  # original NMS
+            weight = np.ones(ovr.shape)
+            weight[ovr > Nt] = 0
+
+        scores[pos:] = weight * scores[pos:]
+
+    # select the boxes and keep the corresponding indexes
+    inds = dets[:, 4][scores > thresh]
+    keep = inds.astype(int)
+    return keep
+
+
+@jit(nopython=True)
+def nms_float_fast(dets: np.ndarray, scores: np.ndarray, thresh: float) -> np.ndarray:
+    """
+    It's different from original nms because we have float coordinates on range [0; 1]
+
+    :param dets: numpy array of boxes with shape: (N, 5). Order: x1, y1, x2, y2, score. All variables in range [0; 1]
+    :param scores:  numpy array of scores
+    :param thresh: IoU value for boxes
+
+    :return: index of boxes to keep
+    """
+    x1 = dets[:, 0]
+    y1 = dets[:, 1]
+    x2 = dets[:, 2]
+    y2 = dets[:, 3]
+
+    areas = (x2 - x1) * (y2 - y1)
+    order = scores.argsort()[::-1]
+
+    keep = []
+    while order.size > 0:
+        i = order[0]
+        keep.append(i)
+        xx1 = np.maximum(x1[i], x1[order[1:]])
+        yy1 = np.maximum(y1[i], y1[order[1:]])
+        xx2 = np.minimum(x2[i], x2[order[1:]])
+        yy2 = np.minimum(y2[i], y2[order[1:]])
+
+        w = np.maximum(0.0, xx2 - xx1)
+        h = np.maximum(0.0, yy2 - yy1)
+        inter = w * h
+        ovr = inter / (areas[i] + areas[order[1:]] - inter)
+        inds = np.where(ovr <= thresh)[0]
+        order = order[inds + 1]
+
+    return keep
+
+
+def nms_method(
+    boxes,
+    scores,
+    labels,
+    method: int = 3,
+    iou_thr: float = 0.5,
+    sigma: float = 0.5,
+    thresh: float = 0.001,
+    weights: Optional[List[float]] = None,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """
+    Perform NMS on a list of boxes, scores, and labels from multiple models.
+
+    :param boxes: list of boxes predictions from each model, each box is 4 numbers. It has 3 dimensions (models_number, model_preds, 4). Order of boxes: x1, y1, x2, y2. We expect float normalized coordinates [0; 1].
+    :param scores: list of scores for each model.
+    :param labels: list of labels for each model.
+    :param method: 1 - linear soft-NMS, 2 - gaussian soft-NMS, 3 - standard NMS.
+    :param iou_thr: IoU value for boxes to be a match.
+    :param sigma: Sigma value for SoftNMS.
+    :param thresh: threshold for boxes to keep (important for SoftNMS).
+    :param weights: list of weights for each model. Default: None, which means weight == 1 for each model.
+
+    :return: tuple of (boxes, scores, labels) after NMS.
+    """
+
+    # If weights are specified
+    if weights is not None:
+        if len(boxes) != len(weights):
+            print("Incorrect number of weights: {}. Must be: {}. Skip it".format(len(weights), len(boxes)))
+        else:
+            weights = np.array(weights)
+            for i in range(len(weights)):
+                scores[i] = (np.array(scores[i]) * weights[i]) / weights.sum()
+
+    # Do the checks and skip empty predictions
+    filtered_boxes = []
+    filtered_scores = []
+    filtered_labels = []
+    for i in range(len(boxes)):
+        if len(boxes[i]) != len(scores[i]) or len(boxes[i]) != len(labels[i]):
+            print(
+                "Check length of boxes and scores and labels: {} {} {} at position: {}. Boxes are skipped!".format(
+                    len(boxes[i]), len(scores[i]), len(labels[i]), i
+                )
+            )
+            continue
+        if len(boxes[i]) == 0:
+            # print('Empty boxes!')
+            continue
+        filtered_boxes.append(boxes[i])
+        filtered_scores.append(scores[i])
+        filtered_labels.append(labels[i])
+
+    # We concatenate everything
+    boxes = np.concatenate(filtered_boxes)
+    scores = np.concatenate(filtered_scores)
+    labels = np.concatenate(filtered_labels)
+
+    # Fix coordinates and removed zero area boxes
+    boxes, scores, labels = prepare_boxes(boxes, scores, labels)
+
+    # Run NMS independently for each label
+    unique_labels = np.unique(labels)
+    final_boxes = []
+    final_scores = []
+    final_labels = []
+    for l in unique_labels:
+        condition = labels == l
+        boxes_by_label = boxes[condition]
+        scores_by_label = scores[condition]
+        labels_by_label = np.array([l] * len(boxes_by_label))
+
+        if method != 3:
+            keep = cpu_soft_nms_float(
+                boxes_by_label.copy(), scores_by_label.copy(), Nt=iou_thr, sigma=sigma, thresh=thresh, method=method
+            )
+        else:
+            # Use faster function
+            keep = nms_float_fast(boxes_by_label, scores_by_label, thresh=iou_thr)
+
+        final_boxes.append(boxes_by_label[keep])
+        final_scores.append(scores_by_label[keep])
+        final_labels.append(labels_by_label[keep])
+    final_boxes = np.concatenate(final_boxes)
+    final_scores = np.concatenate(final_scores)
+    final_labels = np.concatenate(final_labels)
+
+    return final_boxes, final_scores, final_labels
+
+
+def nms(
+    boxes: List[np.ndarray],
+    scores: List[np.ndarray],
+    labels: List[np.ndarray],
+    iou_thr: float = 0.5,
+    weights: Optional[List[float]] = None,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """
+    Short call for standard NMS
+
+    :param boxes: list of boxes predictions from each model, each box is 4 numbers. It has 3 dimensions (models_number, model_preds, 4). Order of boxes: x1, y1, x2, y2. We expect float normalized coordinates [0; 1].
+    :param scores: list of scores for each model.
+    :param labels: list of labels for each model.
+    :param iou_thr: IoU threshold value for boxes.
+    :param weights: list of weights for each model. Default: None, which means weight == 1 for each model.
+
+    :return: Tuple containing the final boxes, scores, and labels after NMS.
+    """
+    return nms_method(boxes, scores, labels, method=3, iou_thr=iou_thr, weights=weights)
+
+
+def soft_nms(
+    boxes: List[np.ndarray],
+    scores: List[np.ndarray],
+    labels: List[np.ndarray],
+    method: int = 2,
+    iou_thr: float = 0.5,
+    sigma: float = 0.5,
+    thresh: float = 0.001,
+    weights: Optional[List[float]] = None,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """
+    Perform soft-NMS on the given set of boxes for each label.
+
+    :param boxes: list of boxes predictions from each model, each box is 4 numbers. It has 3 dimensions (models_number, model_preds, 4). Order of boxes: x1, y1, x2, y2. We expect float normalized coordinates [0; 1].
+    :param scores: list of scores for each model.
+    :param labels: list of labels for each model.
+    :param method: 1 - linear soft-NMS, 2 - gaussian soft-NMS.
+    :param iou_thr: IoU value for boxes to be a match.
+    :param sigma: Sigma value for SoftNMS.
+    :param thresh: threshold for boxes to keep (important for SoftNMS).
+    :param weights: list of weights for each model. Default: None, which means weight == 1 for each model.
+
+    :return: Tuple containing the final boxes, scores, and labels after soft-NMS.
+    """
+    return nms_method(boxes, scores, labels, method=method, iou_thr=iou_thr, sigma=sigma, thresh=thresh, weights=weights)

--- a/src/aws/osml/model_runner/inference/feature_selection.py
+++ b/src/aws/osml/model_runner/inference/feature_selection.py
@@ -3,7 +3,6 @@
 from collections import OrderedDict
 from typing import List, Tuple
 
-from ensemble_boxes import nms, soft_nms
 from geojson import Feature
 
 from aws.osml.model_runner.common import (
@@ -11,6 +10,7 @@ from aws.osml.model_runner.common import (
     FeatureDistillationAlgorithmType,
     get_feature_image_bounds,
 )
+from aws.osml.model_runner.common.ensemble_boxes_nms import nms, soft_nms
 from aws.osml.model_runner.inference.exceptions import FeatureDistillationException
 
 

--- a/test/aws/osml/model_runner/common/test_ensemble_boxes_nms.py
+++ b/test/aws/osml/model_runner/common/test_ensemble_boxes_nms.py
@@ -1,0 +1,118 @@
+# Copyright 2024 Amazon.com, Inc. or its affiliates.
+
+import unittest
+
+import numpy as np
+import pytest
+
+
+class TestNMSMethods(unittest.TestCase):
+    """
+    Unit tests for the Non-Maximum Suppression (NMS) and Soft-NMS functions.
+    """
+
+    def setUp(self):
+        """
+        Sets up mock bounding boxes, scores, and labels for testing.
+        """
+        # Bounding boxes (x1, y1, x2, y2) and scores from two models
+        self.boxes = [
+            np.array([[0.1, 0.1, 0.4, 0.4], [0.15, 0.15, 0.45, 0.45], [0.6, 0.6, 0.9, 0.9]]),  # Model 1
+            np.array([[0.2, 0.2, 0.5, 0.5], [0.7, 0.7, 1.0, 1.0]]),  # Model 2
+        ]
+        self.scores = [
+            np.array([0.9, 0.85, 0.6]),  # Scores for Model 1
+            np.array([0.8, 0.7]),  # Scores for Model 2
+        ]
+        self.labels = [
+            np.array([1, 1, 2]),  # Labels for Model 1
+            np.array([1, 2]),  # Labels for Model 2
+        ]
+
+    def test_prepare_boxes(self):
+        """
+        Test the prepare_boxes function to ensure it:
+        1. Corrects invalid box coordinates.
+        2. Removes boxes with zero area.
+        """
+        from aws.osml.model_runner.common.ensemble_boxes_nms import prepare_boxes
+
+        # Create invalid boxes with out-of-bound coordinates and zero area
+        invalid_boxes = np.array([[-0.1, 0.2, 1.1, 1.2], [0.5, 0.5, 0.5, 0.5]])
+        invalid_scores = np.array([0.9, 0.8])
+        invalid_labels = np.array([1, 1])
+
+        filtered_boxes, filtered_scores, filtered_labels = prepare_boxes(invalid_boxes, invalid_scores, invalid_labels)
+
+        # Assertions
+        assert filtered_boxes.shape[0] == 1
+        assert np.all(filtered_boxes >= 0) and np.all(filtered_boxes <= 1)
+
+    def test_nms(self):
+        """
+        Test the standard NMS function to ensure it suppresses overlapping boxes
+        based on an IoU threshold of 0.5.
+        """
+        from aws.osml.model_runner.common.ensemble_boxes_nms import nms
+
+        final_boxes, final_scores, final_labels = nms(self.boxes, self.scores, self.labels, 0.5)
+
+        # Assertions
+        assert final_boxes.shape[0] == 4
+
+    def test_soft_nms(self):
+        """
+        Test the Soft-NMS function with the linear method (method=1).
+        """
+        from aws.osml.model_runner.common.ensemble_boxes_nms import soft_nms
+
+        final_boxes, final_scores, final_labels = soft_nms(self.boxes, self.scores, self.labels, 1, 0.5)
+
+        # Assertions
+        assert final_boxes.shape[0] == 5
+
+    def test_nms_fast(self):
+        """
+        Test the optimized NMS implementation (nms_fast) for speed and correctness.
+        """
+        from aws.osml.model_runner.common.ensemble_boxes_nms import nms_fast
+
+        dets = np.array([[0.1, 0.1, 0.4, 0.4], [0.15, 0.15, 0.45, 0.45], [0.6, 0.6, 0.9, 0.9]])
+        scores = np.array([0.9, 0.85, 0.6])
+
+        keep = nms_fast(dets, scores, 0.5)
+
+        # Assertions
+        assert len(keep) == 2
+
+    def test_nms_with_weights(self):
+        """
+        Test the NMS function with model weights applied to scores.
+        """
+        from aws.osml.model_runner.common.ensemble_boxes_nms import nms
+
+        weights = [0.5, 0.5]  # Apply equal weights to both models
+        final_boxes, final_scores, final_labels = nms(self.boxes, self.scores, self.labels, 0.5, weights=weights)
+
+        # Assertions
+        assert final_boxes.shape[0] == 4
+        assert np.all(final_scores <= 1.0)  # Scores should remain normalized
+
+    def test_invalid_input_lengths(self):
+        """
+        Test that NMS raises a ValueError when input lengths are mismatched.
+        """
+        from aws.osml.model_runner.common.ensemble_boxes_nms import nms
+
+        # Mismatched input: boxes have fewer entries than scores and labels
+        invalid_boxes = [np.array([[0.1, 0.1, 0.4, 0.4]])]  # 1 box
+        invalid_scores = [np.array([0.9, 0.8])]  # 2 scores
+        invalid_labels = [np.array([1, 2])]  # 2 labels
+
+        # Verify that a ValueError is raised with a clear message
+        with pytest.raises(ValueError):
+            nms(invalid_boxes, invalid_scores, invalid_labels, 0.5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Issue #, if available:** n/a

### Notes
This file contains code for performing non-maximum suppression (NMS) on bounding boxes obtained from multiple object detection models. The code was originally taken from the following GitHub repository:

https://github.com/ZFTurbo/Weighted-Boxes-Fusion/blob/master/ensemble_boxes/ensemble_boxes_nms.py

The original author is 'ZFTurbo' (https://kaggle.com/zfturbo).

This implementation provides functions for standard NMS, linear soft-NMS, and gaussian soft-NMS. It also includes a method for preparing the boxes, scores, and labels before applying NMS.

Along with some motification to match the conventional OSML styles such as typings and docstrings. 

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
