### PR TITLE
feat: add endpoint load scheduler

### DIFF
--- a/src/aws/osml/model_runner/queue/__init__.py
+++ b/src/aws/osml/model_runner/queue/__init__.py
@@ -1,7 +1,8 @@
-#  Copyright 2023-2024 Amazon.com, Inc. or its affiliates.
+#  Copyright 2023-2025 Amazon.com, Inc. or its affiliates.
 
 # Telling flake8 to not flag errors in this file. It is normal that these classes are imported but not used in an
 # __init__.py file.
 # flake8: noqa
 
+from .buffered_image_request_queue import BufferedImageRequestQueue
 from .request_queue import RequestQueue

--- a/src/aws/osml/model_runner/queue/buffered_image_request_queue.py
+++ b/src/aws/osml/model_runner/queue/buffered_image_request_queue.py
@@ -1,0 +1,212 @@
+#  Copyright 2025 Amazon.com, Inc. or its affiliates.
+
+import json
+import logging
+import time
+from typing import List
+
+import boto3
+from botocore.exceptions import ClientError
+
+from aws.osml.model_runner.api import ImageRequest
+from aws.osml.model_runner.app_config import BotoConfig
+from aws.osml.model_runner.database.requested_jobs_table import ImageRequestStatusRecord, RequestedJobsTable
+
+logger = logging.getLogger(__name__)
+
+
+class BufferedImageRequestQueue:
+    """
+    A queue that buffers image requests from SQS and manages them in DynamoDB.
+    """
+
+    def __init__(
+        self,
+        image_queue_url: str,
+        image_dlq_url: str,
+        requested_jobs_table: RequestedJobsTable,
+        max_jobs_lookahead: int = 500,
+        retry_time: int = 600,
+        max_retry_attempts: int = 1,
+    ):
+        """
+        Initialize the buffered image request queue.
+
+        :param image_queue_url: name of the SQS queue containing image requests
+        :param image_dlq_url: name of the SQS dead letter queue for problematic image requests
+        :param requested_jobs_table: DynamoDB table for tracking request status
+        :param max_jobs_lookahead: Maximum number of jobs to look ahead in the queue
+        :param retry_time: Time in seconds before retrying failed requests
+        :param max_retry_attempts: Maximum number of retry attempts for failed requests
+        """
+        self.requested_jobs_table = requested_jobs_table
+        self.max_jobs_lookahead = max_jobs_lookahead
+        self.retry_time = retry_time
+        self.max_retry_attempts = max_retry_attempts
+
+        self.sqs_client = boto3.client("sqs", config=BotoConfig.default)
+        self.image_queue_url = image_queue_url
+        self.image_dlq_url = image_dlq_url
+
+        self.cw_client = boto3.client("cloudwatch", config=BotoConfig.default)
+
+    def get_outstanding_requests(self) -> List[ImageRequestStatusRecord]:
+        """
+        Get the list of outstanding image requests by combining requests from the SQS queue
+        and existing requests in the DynamoDB table.
+
+        :return: List of outstanding image request status records
+        """
+        try:
+            # Load the outstanding requests that have already been pulled off the queue
+            outstanding_requests = self.requested_jobs_table.get_outstanding_requests()
+
+            # Clean up any completed or failed requests
+            outstanding_requests = self._purge_finished_requests(outstanding_requests)
+
+            # If our buffer isn't at full capacity pull new messages from the queue
+            # and store them in the buffer.
+            if len(outstanding_requests) < self.max_jobs_lookahead:
+                outstanding_requests.extend(
+                    self._fetch_new_requests(max_messages_to_fetch=self.max_jobs_lookahead - len(outstanding_requests))
+                )
+
+            current_time = int(time.time())
+            visible_requests = [
+                request for request in outstanding_requests if request.last_attempt + self.retry_time < current_time
+            ]
+
+            # Output custom CW metric with size of outstanding requests list.
+            self._emit_buffered_queue_metrics(
+                num_buffered_requests=len(outstanding_requests), num_visible_requests=len(visible_requests)
+            )
+
+            return visible_requests
+        except Exception as e:
+            logger.error(f"Error getting outstanding requests: {e}")
+            return []
+
+    def _fetch_new_requests(self, max_messages_to_fetch: int) -> List[ImageRequestStatusRecord]:
+        """
+        Fetch new requests from the SQS queue and add them to DynamoDB.
+
+        :return: List of new image request status records
+        """
+        outstanding_requests = []
+        messages_to_fetch = max_messages_to_fetch
+        while messages_to_fetch > 0:
+            try:
+                # Use the SQS batch read function to retrieve multiple image requests from the queue if possible.
+                response = self.sqs_client.receive_message(
+                    QueueUrl=self.image_queue_url,
+                    MaxNumberOfMessages=min(10, messages_to_fetch),
+                    WaitTimeSeconds=1,  # Use short polling for batch requests
+                    AttributeNames=["All"],
+                    MessageAttributeNames=["All"],
+                )
+
+                # If there are no messages available exit the loop
+                messages = response.get("Messages", [])
+                if not messages:
+                    break
+
+                for message in messages:
+                    try:
+                        # Attempt to create a valid ImageRequest from the queue body
+                        message_body = message["Body"]
+                        json_body = json.loads(message_body)
+                        image_request = ImageRequest.from_external_message(json_body)
+                        if not image_request.is_valid():
+                            raise ValueError(f"Invalid image request: {message_body}")
+
+                        # If we have a valid request move it from the SQS queue into our DDB table. The order of these
+                        # operations is important to ensure we don't lose any requests. (i.e. ensure they are added
+                        # to the table before we delete them from the queue).
+                        request_status_record = self.requested_jobs_table.add_new_request(image_request)
+                        self.sqs_client.delete_message(QueueUrl=self.image_queue_url, ReceiptHandle=message["ReceiptHandle"])
+                        outstanding_requests.append(request_status_record)
+                        messages_to_fetch -= 1
+
+                    except (json.JSONDecodeError, ValueError) as e:
+                        logger.info(f"Invalid message received. Moving to DLQ. {e}")
+                        self._handle_invalid_message(message)
+                    except ClientError:
+                        # In this case we were unable to either add the request to the DDB table or remove it from the
+                        # image queue. The table add happens before the delete so if the request is not recorded it
+                        # will be left on the SQS queue for a retry attempt. If the delete attempt failed it will appear
+                        # just like a duplicate SQS message.
+                        logger.error("Unable to move valid image request from input queue to DDB.", exc_info=True)
+
+            except ClientError as e:
+                logger.error(f"Error receiving messages from SQS: {e}")
+                break
+
+        return outstanding_requests
+
+    def _handle_invalid_message(self, message: dict) -> None:
+        """
+        This is the error handling for an invalid or improperly formatted image request.
+        We attempt to move it directly to the DLQ to avoid any unnecessary retries.
+
+        :param message: The invalid SQS message
+        """
+        try:
+            self.sqs_client.send_message(QueueUrl=self.image_dlq_url, MessageBody=message["Body"])
+            self.sqs_client.delete_message(QueueUrl=self.image_queue_url, ReceiptHandle=message["ReceiptHandle"])
+        except ClientError as ce:
+            logger.error("Unable to move invalid image request from input queue to DLQ.")
+            logger.exception(ce)
+
+    def _purge_finished_requests(
+        self, outstanding_requests: List[ImageRequestStatusRecord]
+    ) -> List[ImageRequestStatusRecord]:
+        """
+        Remove completed requests and move failed requests to DLQ.
+
+        :param outstanding_requests: List of current outstanding requests
+        :return: Updated list of outstanding requests
+        """
+        current_outstanding_requests = []
+
+        for request in outstanding_requests:
+            try:
+                if request.num_attempts >= self.max_retry_attempts:
+                    # Move to DLQ if max retries exceeded
+                    self.sqs_client.send_message(
+                        QueueUrl=self.image_dlq_url, MessageBody=json.dumps(request.request_payload)
+                    )
+                    self.requested_jobs_table.complete_request(request.request_payload)
+                elif request.region_count == len(request.regions_complete):
+                    # Complete the request if all regions are processed
+                    self.requested_jobs_table.complete_request(request.request_payload)
+                else:
+                    current_outstanding_requests.append(request)
+            except ClientError:
+                logger.error(f"Unable to cleanup outstanding request {request.job_id}", exc_info=True)
+
+        return current_outstanding_requests
+
+    def _emit_buffered_queue_metrics(self, num_buffered_requests: int, num_visible_requests: int) -> None:
+        """
+        Emit metrics about the number of buffered requests to CloudWatch.
+
+        :param num_buffered_requests: The current number of requests in the buffer
+        :param num_visible_requests: The current number of requests that are waiting to be processed
+        """
+        try:
+            self.cw_client.put_metric_data(
+                MetricData=[
+                    {"MetricName": "ApproximateNumberOfRequestsBuffered", "Unit": "Count", "Value": num_buffered_requests},
+                    {"MetricName": "ApproximateNumberOfRequestsVisible", "Unit": "Count", "Value": num_visible_requests},
+                ],
+                Namespace="OSML/ModelRunner/ImageRequestsQueue",
+            )
+        except ClientError as ce:
+            error_code = ce.response["Error"]["Code"]
+            error_message = ce.response["Error"]["Message"]
+            logger.error(
+                "Failed to emit CloudWatch metrics for buffered requests. "
+                f"Error code: {error_code}, Message: {error_message}"
+            )
+        except Exception as e:
+            logger.error(f"Unexpected error while emitting CloudWatch metrics for buffered requests: {e}", exc_info=True)

--- a/src/aws/osml/model_runner/scheduler/__init__.py
+++ b/src/aws/osml/model_runner/scheduler/__init__.py
@@ -4,5 +4,6 @@
 # __init__.py file.
 # flake8: noqa
 
+from .endpoint_load_image_scheduler import EndpointLoadImageScheduler
 from .fifo_image_scheduler import FIFOImageScheduler
 from .image_scheduler import ImageScheduler

--- a/src/aws/osml/model_runner/scheduler/endpoint_load_image_scheduler.py
+++ b/src/aws/osml/model_runner/scheduler/endpoint_load_image_scheduler.py
@@ -1,0 +1,216 @@
+#  Copyright 2025 Amazon.com, Inc. or its affiliates.
+
+import logging
+from dataclasses import dataclass
+from itertools import groupby
+from operator import attrgetter
+from typing import Dict, List, Optional
+
+import boto3
+from botocore.exceptions import ClientError
+
+from aws.osml.model_runner.api import ImageRequest
+from aws.osml.model_runner.app_config import BotoConfig
+from aws.osml.model_runner.database import ImageRequestStatusRecord
+from aws.osml.model_runner.queue import BufferedImageRequestQueue
+from aws.osml.model_runner.scheduler.image_scheduler import ImageScheduler
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class EndpointUtilizationSummary:
+    """
+    Tracks the load information for a SageMaker endpoint.
+
+    :param endpoint_id: The identifier of the endpoint
+    :param instance_count: Number of instances backing the endpoint
+    :param current_load: Number of images currently being processed
+    :param requests: List of pending requests for this endpoint
+    """
+
+    endpoint_id: str
+    instance_count: int
+    current_load: int
+    requests: List[ImageRequestStatusRecord]
+
+    @property
+    def load_factor(self) -> float:
+        """
+        Calculate the load factor for this endpoint which is just the ratio of load per endpoint instance.
+
+        :return: The load factor (current_load / instance_count)
+        :rtype: float
+        """
+        return self.current_load / max(1, self.instance_count)
+
+
+class EndpointLoadImageScheduler(ImageScheduler):
+    """
+    This class prioritizes image jobs that will make requests against the least utilized model endpoint.
+
+    It does this by using a buffered request queue that will allow us to look ahead some number of requests
+    and then pick the oldest request for the endpoint currently processing the fewest number of regions.
+    """
+
+    def __init__(self, image_request_queue: BufferedImageRequestQueue):
+        """
+        Initialize the load based image scheduler.
+
+        :param image_request_queue: a request queue that buffers messages to enable lookahead
+        """
+        self.image_request_queue = image_request_queue
+        self.sm_client = boto3.client("sagemaker", config=BotoConfig.default)
+
+    def get_next_scheduled_request(self) -> Optional[ImageRequest]:
+        """
+        Get the image request for the endpoint with the lowest load.
+
+        :return: The next image request to process, if any
+        """
+        try:
+            logger.debug("Starting image processing request selection process")
+            outstanding_requests = self.image_request_queue.get_outstanding_requests()
+            if not outstanding_requests:
+                logger.debug("No image processing request available to start")
+                return None
+            logger.debug(f"Retrieved {len(outstanding_requests)} image processing requests from the buffered queue")
+
+            # Group requests by endpoint and calculate loads
+            grouped_requests = self._group_requests_by_endpoint(outstanding_requests)
+            endpoint_utilization = self._calculate_endpoint_utilization(grouped_requests)
+
+            if logger.isEnabledFor(logging.DEBUG):
+                utilization_rows = []
+                for endpoint_summary in endpoint_utilization:
+                    utilization_rows.append(
+                        f"\t{endpoint_summary.endpoint_id}"
+                        f"\t{endpoint_summary.instance_count}"
+                        f"\t{len(endpoint_summary.requests)}"
+                        f"\t{endpoint_summary.current_load}"
+                    )
+                utilization_str = "\n".join(utilization_rows)
+                logger.debug(
+                    "Current Endpoint Utilization:\n"
+                    "  \tEndpoint\tInstance Count\tRequest Count\tCurrent Load\n"
+                    f"  {utilization_str}"
+                )
+
+            # Find next eligible request
+            next_request = self._select_next_eligible_request(endpoint_utilization)
+            if not next_request:
+                logger.debug("No outstanding requests are eligible to start. Stopping scheduling cycle.")
+                return None
+            logger.debug(f"Selected job {next_request.job_id} requested at {next_request.request_time} for processing.")
+
+            # Try to start the next attempt. If the attempt can't be started that usually means the conditional
+            # update of the record failed because another worker started the same request. In that case we
+            # do not return an image processing request because we want this worker to go check the region
+            # queue before starting a new image.
+            if self.image_request_queue.requested_jobs_table.start_next_attempt(next_request):
+                logger.debug(f"Started selected job {next_request.job_id}. Attempt # {next_request.num_attempts +1}")
+                return next_request.request_payload
+
+            logger.debug(
+                f"Unable to start selected job {next_request.job_id}. "
+                "Request was likely started by another worker. Stopping scheduling cycle."
+            )
+            return None
+
+        except Exception as e:
+            logger.error(f"Error getting next scheduled request: {e}", exc_info=True)
+            return None
+
+    def finish_request(self, image_request: ImageRequest, should_retry: bool = False) -> None:
+        """
+        Complete processing of an image request.
+
+        :param image_request: The completed image request
+        :param should_retry: Whether the request should be retried
+        """
+        # Nothing to do here. The requests are fully managed by the buffered queue and do not need manual cleanup.
+        # This is just a noop placeholder for the abstract method defined on the base class.
+        pass
+
+    def _get_endpoint_instance_count(self, endpoint_name: str) -> int:
+        """
+        Get the number of instances backing a SageMaker endpoint.
+
+        :param endpoint_name: Name of the SageMaker endpoint
+        :return: Number of instances backing the endpoint
+        """
+        try:
+            response = self.sm_client.describe_endpoint(EndpointName=endpoint_name)
+            production_variant = response["ProductionVariants"][0]
+            return production_variant.get("CurrentInstanceCount", 1)
+        except ClientError as e:
+            logger.error(f"Error describing endpoint {endpoint_name}: {e}")
+            return 1  # Default to 1 instance if we can't get the count
+
+    def _group_requests_by_endpoint(
+        self, requests: List[ImageRequestStatusRecord]
+    ) -> Dict[str, List[ImageRequestStatusRecord]]:
+        """
+        Group requests by their endpoint ID.
+
+        :param requests: List of request records to group
+        :return: Dictionary mapping endpoint IDs to lists of requests
+        """
+        sorted_requests = sorted(requests, key=attrgetter("endpoint_id"))
+        return {endpoint_id: list(group) for endpoint_id, group in groupby(sorted_requests, key=attrgetter("endpoint_id"))}
+
+    def _calculate_endpoint_utilization(
+        self, grouped_requests: Dict[str, List[ImageRequestStatusRecord]]
+    ) -> List[EndpointUtilizationSummary]:
+        """
+        Calculate load information for each endpoint.
+
+        The load of an endpoint is estimated by counting up the total number of regions that still need to be
+        processed for running requests against that endpoint. This is approximate because there is still some
+        variance in size for regions but overall this heuristic recognizes that the whole image sizes will vary
+        widely and larger images will place a more substantial load on the endpoints.
+
+        :param grouped_requests: Requests grouped by endpoint ID
+        :return: List of endpoint load information
+        """
+        endpoint_loads = []
+        for endpoint_id, requests in grouped_requests.items():
+            instance_count = self._get_endpoint_instance_count(endpoint_id)
+
+            current_load = 0
+            for r in requests:
+                if r.region_count is None:
+                    if r.last_attempt > 0:
+                        # Attempt has started but we don't have a count of regions yet. Assume it is 1
+                        current_load += 1
+                else:
+                    current_load += r.region_count - len(r.regions_complete)
+
+            endpoint_loads.append(
+                EndpointUtilizationSummary(
+                    endpoint_id=endpoint_id, instance_count=instance_count, current_load=current_load, requests=requests
+                )
+            )
+        return endpoint_loads
+
+    def _select_next_eligible_request(
+        self, endpoint_loads: List[EndpointUtilizationSummary]
+    ) -> Optional[ImageRequestStatusRecord]:
+        """
+        Find the next eligible request to process.
+
+        :param endpoint_loads: List of endpoint load information
+        :return: The next request to process, if any
+        """
+        oldest_request = None
+        last_load = None
+        for endpoint_load in sorted(endpoint_loads, key=lambda x: x.load_factor):
+            if last_load is not None and endpoint_load.load_factor > last_load:
+                break
+            if endpoint_load.requests:
+                current_oldest_request = min(endpoint_load.requests, key=attrgetter("request_time"))
+                if oldest_request is None or oldest_request.request_time > current_oldest_request.request_time:
+                    oldest_request = current_oldest_request
+                    last_load = endpoint_load.load_factor
+
+        return oldest_request

--- a/test/aws/osml/model_runner/queue/test_buffered_image_request_queue.py
+++ b/test/aws/osml/model_runner/queue/test_buffered_image_request_queue.py
@@ -1,0 +1,180 @@
+#  Copyright 2025 Amazon.com, Inc. or its affiliates.
+
+import json
+import time
+import unittest
+
+import boto3
+from moto import mock_aws
+
+from aws.osml.model_runner.api import ImageRequest
+from aws.osml.model_runner.database.requested_jobs_table import RequestedJobsTable
+from aws.osml.model_runner.queue.buffered_image_request_queue import BufferedImageRequestQueue
+
+
+@mock_aws
+class TestBufferedImageRequestQueue(unittest.TestCase):
+    """Test cases for BufferedImageRequestQueue"""
+
+    def setUp(self):
+        """Set up test fixtures before each test method."""
+        # Set up mock AWS resources
+        self.sqs = boto3.client("sqs")
+        self.dynamodb = boto3.resource("dynamodb")
+        self.cloudwatch = boto3.client("cloudwatch")
+
+        # Create SQS queues
+        self.queue_url = self.sqs.create_queue(QueueName="test-image-queue")["QueueUrl"]
+        self.dlq_url = self.sqs.create_queue(QueueName="test-image-dlq")["QueueUrl"]
+
+        # Create DynamoDB table
+        self.table_name = "test-requested-jobs"
+        self.dynamodb.create_table(
+            TableName=self.table_name,
+            KeySchema=[{"AttributeName": "endpoint_id", "KeyType": "HASH"}, {"AttributeName": "job_id", "KeyType": "RANGE"}],
+            AttributeDefinitions=[
+                {"AttributeName": "endpoint_id", "AttributeType": "S"},
+                {"AttributeName": "job_id", "AttributeType": "S"},
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+
+        # Create RequestedJobsTable instance
+        self.jobs_table = RequestedJobsTable(self.table_name)
+
+        # Create BufferedImageRequestQueue instance
+        self.queue = BufferedImageRequestQueue(
+            image_queue_url=self.queue_url,
+            image_dlq_url=self.dlq_url,
+            requested_jobs_table=self.jobs_table,
+            max_jobs_lookahead=10,
+            retry_time=60,
+            max_retry_attempts=2,
+        )
+
+    def create_sample_image_request_message_body(self, job_name: str = "test-job") -> dict:
+        """Helper method to create a sample image request message"""
+        return {
+            "jobName": job_name,
+            "jobId": f"{job_name}-id",
+            "imageUrls": ["s3://test-bucket/test.nitf"],
+            "outputs": [
+                {"type": "S3", "bucket": "test-bucket", "prefix": "results"},
+                {"type": "Kinesis", "stream": "test-stream", "batchSize": 1000},
+            ],
+            "imageProcessor": {"name": "test-model", "type": "SM_ENDPOINT"},
+            "imageProcessorTileSize": 2048,
+            "imageProcessorTileOverlap": 50,
+        }
+
+    def test_get_outstanding_requests_empty_queue(self):
+        """Test getting outstanding requests when queue is empty"""
+        requests = self.queue.get_outstanding_requests()
+        self.assertEqual(len(requests), 0)
+
+    def test_get_outstanding_requests_with_valid_messages(self):
+        """Test getting outstanding requests with valid messages in queue"""
+        # Add messages to queue
+        for i in range(3):
+            message = self.create_sample_image_request_message_body(f"job-{i}")
+            self.sqs.send_message(QueueUrl=self.queue_url, MessageBody=json.dumps(message))
+
+        # Get outstanding requests
+        requests = self.queue.get_outstanding_requests()
+        self.assertEqual(len(requests), 3)
+        self.assertEqual(requests[0].job_id, "job-0-id")
+
+    def test_handle_invalid_message(self):
+        """Test handling of invalid messages"""
+        # Send invalid message to queue
+        self.sqs.send_message(QueueUrl=self.queue_url, MessageBody="invalid-json")
+
+        # Process messages
+        requests = self.queue.get_outstanding_requests()
+
+        # Verify invalid message was moved to DLQ
+        dlq_messages = self.sqs.receive_message(QueueUrl=self.dlq_url, MaxNumberOfMessages=10).get("Messages", [])
+
+        self.assertEqual(len(requests), 0)
+        self.assertEqual(len(dlq_messages), 1)
+        self.assertEqual(dlq_messages[0]["Body"], "invalid-json")
+
+    def test_retry_failed_requests(self):
+        """Test retry mechanism for failed requests"""
+        # Create a request and add it to the table
+        request_data = self.create_sample_image_request_message_body()
+        image_request = ImageRequest.from_external_message(request_data)
+        status_record = self.jobs_table.add_new_request(image_request)
+
+        # Force update of the item to look like it has already been run at sometime
+        # in the past (longer than the retry timeout)
+        self.jobs_table.table.update_item(
+            Key={"endpoint_id": status_record.endpoint_id, "job_id": status_record.job_id},
+            UpdateExpression="SET last_attempt = :time, num_attempts = num_attempts + :inc",
+            ExpressionAttributeValues={":time": int(time.time()) - (self.queue.retry_time + 5), ":inc": 1},
+            ReturnValues="UPDATED_NEW",
+        )
+
+        # Get outstanding requests, the request should be returned
+        requests = self.queue.get_outstanding_requests()
+        self.assertEqual(len(requests), 1)
+        self.assertEqual(requests[0].num_attempts, 1)
+
+    def test_purge_completed_requests(self):
+        """Test purging of completed requests"""
+        # Create a completed request
+        request_data = self.create_sample_image_request_message_body()
+        image_request = ImageRequest.from_external_message(request_data)
+
+        self.jobs_table.add_new_request(image_request)
+        self.jobs_table.update_request_details(image_request, region_count=1)
+        self.jobs_table.complete_region(image_request, "region1")
+
+        # Get outstanding requests (should purge completed)
+        requests = self.queue.get_outstanding_requests()
+        self.assertEqual(len(requests), 0)
+
+    def test_max_retry_attempts_exceeded(self):
+        """Test handling of requests that exceed max retry attempts"""
+        # Create a request and add it to the table
+        request_data = self.create_sample_image_request_message_body()
+        image_request = ImageRequest.from_external_message(request_data)
+        status_record = self.jobs_table.add_new_request(image_request)
+
+        # Use up all of the retries
+        for i in range(self.queue.max_retry_attempts + 1):
+            self.jobs_table.start_next_attempt(status_record)
+            status_record.num_attempts += 1
+
+        # Get outstanding requests and make sure the attempt is not among them
+        requests = self.queue.get_outstanding_requests()
+        self.assertEqual(len(requests), 0)
+
+        # Verify message was moved to DLQ
+        dlq_messages = self.sqs.receive_message(QueueUrl=self.dlq_url, MaxNumberOfMessages=10).get("Messages", [])
+
+        self.assertEqual(len(dlq_messages), 1)
+
+    def test_respect_max_jobs_lookahead(self):
+        """Test that the queue respects the max_jobs_lookahead limit"""
+        # Add more messages than max_jobs_lookahead
+        for i in range(self.queue.max_jobs_lookahead + 5):
+            message = self.create_sample_image_request_message_body(f"job-{i}")
+            self.sqs.send_message(QueueUrl=self.queue_url, MessageBody=json.dumps(message))
+
+        # Get outstanding requests
+        requests = self.queue.get_outstanding_requests()
+        self.assertEqual(len(requests), self.queue.max_jobs_lookahead)
+
+    def tearDown(self):
+        """Clean up test fixtures after each test method."""
+        # Clean up DynamoDB table
+        self.dynamodb.Table(self.table_name).delete()
+
+        # Clean up SQS queues
+        self.sqs.delete_queue(QueueUrl=self.queue_url)
+        self.sqs.delete_queue(QueueUrl=self.dlq_url)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/aws/osml/model_runner/scheduler/test_endpoint_load_image_scheduler.py
+++ b/test/aws/osml/model_runner/scheduler/test_endpoint_load_image_scheduler.py
@@ -1,0 +1,189 @@
+#  Copyright 2025 Amazon.com, Inc. or its affiliates.
+
+import time
+import unittest
+from typing import List, Optional
+from unittest.mock import Mock
+
+import boto3
+from moto import mock_aws
+
+from aws.osml.model_runner.api import ImageRequest
+from aws.osml.model_runner.database import ImageRequestStatusRecord
+from aws.osml.model_runner.scheduler.endpoint_load_image_scheduler import (
+    EndpointLoadImageScheduler,
+    EndpointUtilizationSummary,
+)
+
+
+@mock_aws
+class TestEndpointLoadImageScheduler(unittest.TestCase):
+    """Test cases for EndpointLoadImageScheduler"""
+
+    def setUp(self):
+        """Set up test fixtures before each test method."""
+        # Set up mock AWS resources
+        self.sagemaker = boto3.client("sagemaker")
+
+        # Create mock endpoints in SageMaker
+        self.endpoints = {
+            "endpoint1": {"InstanceCount": 2},
+            "endpoint2": {"InstanceCount": 1},
+            "endpoint3": {"InstanceCount": 3},
+        }
+
+        for endpoint_id, config in self.endpoints.items():
+            self.sagemaker.create_model(
+                ModelName=f"{endpoint_id}-model", PrimaryContainer={"Image": "test-model-container-image"}
+            )
+            self.sagemaker.create_endpoint_config(
+                EndpointConfigName=f"{endpoint_id}-config",
+                ProductionVariants=[
+                    {
+                        "InstanceType": "ml.m5.xlarge",
+                        "InitialInstanceCount": config["InstanceCount"],
+                        "VariantName": "AllTraffic",
+                        "ModelName": f"{endpoint_id}-model",
+                    }
+                ],
+            )
+
+            self.sagemaker.create_endpoint(EndpointName=f"{endpoint_id}-model", EndpointConfigName=f"{endpoint_id}-config")
+
+        # Create mock BufferedImageRequestQueue
+        self.mock_queue = Mock()
+
+        # Create scheduler
+        self.scheduler = EndpointLoadImageScheduler(image_request_queue=self.mock_queue)
+
+    def create_sample_image_request(self, job_name: str = "test-job", model_name: str = "endpoint1-model") -> ImageRequest:
+        """Helper method to create a sample ImageRequest"""
+        return ImageRequest.from_external_message(
+            {
+                "jobName": job_name,
+                "jobId": f"{job_name}-id",
+                "imageUrls": ["s3://test-bucket/test.nitf"],
+                "outputs": [
+                    {"type": "S3", "bucket": "test-bucket", "prefix": "results"},
+                    {"type": "Kinesis", "stream": "test-stream", "batchSize": 1000},
+                ],
+                "imageProcessor": {"name": model_name, "type": "SM_ENDPOINT"},
+                "imageProcessorTileSize": 2048,
+                "imageProcessorTileOverlap": 50,
+            }
+        )
+
+    def create_status_record(
+        self,
+        job_name: str,
+        model_name: str,
+        request_time: Optional[int] = None,
+        last_attempt: Optional[int] = None,
+        num_attempts: Optional[int] = None,
+        regions_complete: Optional[List[str]] = None,
+        region_count: Optional[int] = None,
+    ) -> ImageRequestStatusRecord:
+        """Helper method to create a status record"""
+        image_request = self.create_sample_image_request(job_name, model_name)
+        image_status_record = ImageRequestStatusRecord.new_from_request(image_request)
+        if request_time is not None:
+            image_status_record.request_time = request_time
+        if last_attempt is not None:
+            image_status_record.last_attempt = last_attempt
+        if num_attempts is not None:
+            image_status_record.num_attempts = num_attempts
+        if regions_complete is not None:
+            image_status_record.regions_complete = regions_complete
+        if region_count is not None:
+            image_status_record.region_count = region_count
+        return image_status_record
+
+    def test_get_next_scheduled_request_no_requests(self):
+        """Test scheduling when there are no requests"""
+        self.mock_queue.get_outstanding_requests.return_value = []
+        result = self.scheduler.get_next_scheduled_request()
+        self.assertIsNone(result)
+
+    def test_get_next_scheduled_request_single_endpoint(self):
+        """Test scheduling with requests for a single endpoint"""
+        time_in_past = int(time.time() - 5)
+        status_records = [
+            self.create_status_record("job1", "endpoint1-model", request_time=time_in_past),
+            self.create_status_record("job2", "endpoint1-model", request_time=time_in_past + 1),
+        ]
+
+        self.mock_queue.get_outstanding_requests.return_value = status_records
+        self.mock_queue.requested_jobs_table.start_next_attempt.return_value = True
+
+        result = self.scheduler.get_next_scheduled_request()
+        self.assertIsNotNone(result)
+        self.assertEqual(result.job_id, "job1-id")
+
+    def test_get_next_scheduled_request_multiple_endpoints(self):
+        """Test scheduling with requests across multiple endpoints"""
+        time_in_past = int(time.time() - 10)
+        status_records = [
+            self.create_status_record("job1", "endpoint1-model", request_time=time_in_past + 1),
+            self.create_status_record("job2", "endpoint2-model", request_time=time_in_past),
+            self.create_status_record("job3", "endpoint3-model", request_time=time_in_past + 2),
+        ]
+
+        self.mock_queue.get_outstanding_requests.return_value = status_records
+        self.mock_queue.requested_jobs_table.start_next_attempt.return_value = True
+
+        result = self.scheduler.get_next_scheduled_request()
+        self.assertIsNotNone(result)
+        # Should choose job2 because all 3 endpoints have no load and it was submitted first
+        self.assertEqual(result.job_id, "job2-id")
+
+    def test_get_next_scheduled_request_with_existing_load(self):
+        """Test scheduling considering existing endpoint load"""
+        status_records = [
+            # endpoint1 (2 instances) has 3 running jobs
+            self.create_status_record("job1", "endpoint1-model", region_count=1),
+            self.create_status_record("job2", "endpoint1-model", region_count=1),
+            self.create_status_record("job3", "endpoint1-model", region_count=1),
+            # endpoint2 (1 instance) has 1 running job
+            self.create_status_record("job4", "endpoint2-model", region_count=1),
+            # endpoint3 (3 instances) has no running jobs
+            self.create_status_record("job5", "endpoint3-model"),
+        ]
+
+        self.mock_queue.get_outstanding_requests.return_value = status_records
+        self.mock_queue.requested_jobs_table.start_next_attempt.return_value = True
+
+        result = self.scheduler.get_next_scheduled_request()
+        self.assertIsNotNone(result)
+        # Should choose endpoint3 as it has lowest load factor (0/3)
+        self.assertEqual(result.job_id, "job5-id")
+
+    def test_get_next_scheduled_request_start_attempt_failure(self):
+        """Test scheduling when start_next_attempt fails"""
+        status_records = [self.create_status_record("job1", "endpoint1-model")]
+
+        self.mock_queue.get_outstanding_requests.return_value = status_records
+        self.mock_queue.requested_jobs_table.start_next_attempt.return_value = False
+
+        result = self.scheduler.get_next_scheduled_request()
+        self.assertIsNone(result)
+
+    def test_get_next_scheduled_request_sagemaker_error(self):
+        """Test handling of SageMaker API errors"""
+        status_records = [
+            self.create_status_record("job1", "nonexistent-endpoint", region_count=1),
+            self.create_status_record("job2", "endpoint3-model", region_count=2),
+        ]
+
+        self.mock_queue.get_outstanding_requests.return_value = status_records
+        self.mock_queue.requested_jobs_table.start_next_attempt.return_value = True
+
+        result = self.scheduler.get_next_scheduled_request()
+        self.assertIsNotNone(result)
+        # Should choose endpoint2 as it has lowest load factor (2/3) assuming the unknown endpoint
+        # defaulted to 1 instance
+        self.assertEqual(result.job_id, "job2-id")
+
+    def test_endpoint_utilization_summary(self):
+        """Test EndpointUtilizationSummary calculations"""
+        summary = EndpointUtilizationSummary(endpoint_id="test-endpoint", instance_count=2, current_load=4, requests=[])
+        self.assertEqual(summary.load_factor, 2)


### PR DESCRIPTION
This change adds a new endpoint load scheduler to ModelRunner but it does not enable the feature in the application.

The EndpointLoadImageScheduler is a job scheduler that picks an image processing job that will drive requests to the least utilized model endpoint. It estimates an endpoint's utilization as the ratio of incomplete image regions for all jobs sending tiles to that endpoint to the number of instances currently allocated to the endpoint.

That scheduler depends on a new BufferedImageRequestQueue class which is a SQS queue that uses a RequestedJobsTable to provide a look ahead of some number of jobs. This queue mimics regular SQS features like retry visibility timeout and a max retry limit for the jobs and will automatically move problematic or expired requests to the DLQ.

Unit tests using Moto to stub out the AWS services have been added with the expectation that new load and integration test runs will be executed after integration is complete in a future PR.

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
