### PR TITLE
feat: ddb dataclass mixin supports nested dataclasses

### DIFF
--- a/src/aws/osml/model_runner/database/dataclass_ddb_mixin.py
+++ b/src/aws/osml/model_runner/database/dataclass_ddb_mixin.py
@@ -1,8 +1,11 @@
 #  Copyright 2025 Amazon.com, Inc. or its affiliates.
 
-from dataclasses import asdict, fields
+import inspect
+from dataclasses import MISSING, asdict, fields, is_dataclass
 from decimal import Decimal
-from typing import Any, Dict
+from typing import Any, Dict, Type, TypeVar, Union, get_args, get_origin, get_type_hints
+
+T = TypeVar("T")
 
 
 def numeric_to_decimal(value: Any) -> Any:
@@ -60,10 +63,100 @@ def decimal_to_numeric(value: Any) -> Any:
     return value
 
 
+def create_dataclass_from_dict(cls: Type[T], data: dict) -> T:
+    """
+    Creates a dataclass instance from a dictionary, handling nested dataclasses, Optional fields, Lists, and Dicts.
+
+    :param cls: The dataclass type to create
+    :param data: Dictionary containing the data
+
+    :return: An instance of the dataclass populated with the dictionary data
+    """
+    if not is_dataclass(cls):
+        raise ValueError(f"Class {cls.__name__} is not a dataclass")
+
+    if data is None:
+        return None
+
+    # Get type hints for all fields
+    type_hints = get_type_hints(cls)
+
+    # Prepare kwargs for the dataclass constructor
+    kwargs = {}
+
+    for field in fields(cls):
+        field_name = field.name
+        field_type = type_hints[field_name]
+        field_value = data.get(field_name, field.default if field.default is not MISSING else None)
+
+        # Skip if field is not in data and is optional
+        if field_value is None and _is_optional(field_type):
+            continue
+
+        # Process the field value based on its type
+        kwargs[field_name] = _process_field_value(field_type, field_value)
+
+    return cls(**kwargs)
+
+
+def _is_optional(field_type: Type) -> bool:
+    """
+    Determines if a field type is Optional.
+    """
+    origin = get_origin(field_type)
+    return origin is Union and type(None) in get_args(field_type)
+
+
+def _process_field_value(field_type: Type, value: Any) -> Any:
+    """
+    Processes a field value based on its type annotation.
+    Handles nested dataclasses, Lists, Dicts, and Optional types.
+    """
+    if value is None:
+        return None
+
+    # Get the origin type (List, Dict, etc.) and type arguments
+    origin = get_origin(field_type)
+    type_args = get_args(field_type)
+
+    # Handle Optional types
+    if _is_optional(field_type):
+        # Get the actual type from Optional
+        actual_type = next(t for t in type_args if not isinstance(t, type(None)))
+        return _process_field_value(actual_type, value)
+
+    # Handle Lists
+    if origin is list:
+        if not type_args:
+            return value
+        element_type = type_args[0]
+        return [_process_field_value(element_type, item) for item in value]
+
+    # Handle Dictionaries
+    if origin is dict:
+        if not type_args:
+            return value
+        key_type, value_type = type_args
+        return {_process_field_value(key_type, k): _process_field_value(value_type, v) for k, v in value.items()}
+
+    # Handle nested dataclasses
+    if inspect.isclass(field_type) and is_dataclass(field_type):
+        return create_dataclass_from_dict(field_type, value)
+
+    # Handle basic types
+    return value
+
+
 class DataclassDDBMixin:
     """
     This is a mixin that adds the ability to convert a dataclass to/from a dictionary of values suitable
     for use as a DynamoDB Item.
+
+    Note that this mixin supports nested dataclasses but it does not support abstract types or unions. The issue is
+    that the information about the concrete instance type is not fully serialized to the dictionary, only attribute
+    names and values are converted. The information about what types to construct is taken from the type hints and
+    field annotations of the dataclass. A dataclass definition that contains an abstract type will not have enough
+    information to fully reconstruct the object instance.
     """
 
     def to_ddb_item(self) -> Dict[str, Any]:
@@ -94,5 +187,5 @@ class DataclassDDBMixin:
         # the inheriting class's attributes and methods.
         field_names = {f.name for f in fields(cls)}
         filtered_dict = {k: v for k, v in dictionary.items() if k in field_names}
-        typed_dict = decimal_to_numeric(filtered_dict)
-        return cls(**typed_dict)
+        numeric_dict = decimal_to_numeric(filtered_dict)
+        return create_dataclass_from_dict(cls, numeric_dict)

--- a/src/aws/osml/model_runner/queue/buffered_image_request_queue.py
+++ b/src/aws/osml/model_runner/queue/buffered_image_request_queue.py
@@ -1,5 +1,6 @@
 #  Copyright 2025 Amazon.com, Inc. or its affiliates.
 
+import dataclasses
 import json
 import logging
 import time
@@ -173,7 +174,7 @@ class BufferedImageRequestQueue:
                 if request.num_attempts >= self.max_retry_attempts:
                     # Move to DLQ if max retries exceeded
                     self.sqs_client.send_message(
-                        QueueUrl=self.image_dlq_url, MessageBody=json.dumps(request.request_payload)
+                        QueueUrl=self.image_dlq_url, MessageBody=json.dumps(dataclasses.asdict(request.request_payload))
                     )
                     self.requested_jobs_table.complete_request(request.request_payload)
                 elif request.region_count == len(request.regions_complete):


### PR DESCRIPTION
This change expands the DataclassDDBMixin to support dataclasses that have nested dataclass fields. The previous implementation only supported native types which is a limitation that became apparent when integrating the requested_jobs_table in with real requests decoded from the image queue.

Unit tests have been updated to test the nested dataclass cases.

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x]  Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
