### PR TITLE
fix: incorrect purge of in-progress image jobs

### DIFF
--- a/test/aws/osml/model_runner/scheduler/test_endpoint_load_image_scheduler.py
+++ b/test/aws/osml/model_runner/scheduler/test_endpoint_load_image_scheduler.py
@@ -52,6 +52,7 @@ class TestEndpointLoadImageScheduler(unittest.TestCase):
 
         # Create mock BufferedImageRequestQueue
         self.mock_queue = Mock()
+        self.mock_queue.retry_time = 600
 
         # Create scheduler
         self.scheduler = EndpointLoadImageScheduler(image_request_queue=self.mock_queue)


### PR DESCRIPTION
These changes fixes a problem found with the scheduler discovered during integration testing. The buffered queue was incorrectly filtering requests as soon as the number of attempts matched the max number of attempts. If a customer ran without retries that would cause results to be moved to the DLQ as soon as they had started giving no time for the actual job to complete. During this debugging it was also noted that the metrics for the number of requests visible on the queue were not being emitted because they were being written directly to CloudWatch (which is an action MR does not have permissions for) instead of being emitted as embedded metrics to the log stream. 

Both of those problems have been fixed by the changes in this PR and the unit tests were updated to better exercise the problematic data flows.

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
