### PR TITLE
fix: changed NMS to select features based on index position instead of a hash-based lookup

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -17,4 +17,4 @@ partial_branches =
 
 show_missing = True
 
-fail_under = 87
+fail_under = 89

--- a/test/aws/osml/model_runner/common/test_ensemble_boxes_nms.py
+++ b/test/aws/osml/model_runner/common/test_ensemble_boxes_nms.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Amazon.com, Inc. or its affiliates.
+# Copyright 2024-2025 Amazon.com, Inc. or its affiliates.
 
 import unittest
 
@@ -55,7 +55,7 @@ class TestNMSMethods(unittest.TestCase):
         """
         from aws.osml.model_runner.common.ensemble_boxes_nms import nms
 
-        final_boxes, final_scores, final_labels = nms(self.boxes, self.scores, self.labels, 0.5)
+        final_boxes, final_scores, final_labels, indices = nms(self.boxes, self.scores, self.labels, 0.5)
 
         # Assertions
         assert final_boxes.shape[0] == 4
@@ -66,7 +66,7 @@ class TestNMSMethods(unittest.TestCase):
         """
         from aws.osml.model_runner.common.ensemble_boxes_nms import soft_nms
 
-        final_boxes, final_scores, final_labels = soft_nms(self.boxes, self.scores, self.labels, 1, 0.5)
+        final_boxes, final_scores, final_labels, indices = soft_nms(self.boxes, self.scores, self.labels, 1, 0.5)
 
         # Assertions
         assert final_boxes.shape[0] == 5
@@ -92,7 +92,7 @@ class TestNMSMethods(unittest.TestCase):
         from aws.osml.model_runner.common.ensemble_boxes_nms import nms
 
         weights = [0.5, 0.5]  # Apply equal weights to both models
-        final_boxes, final_scores, final_labels = nms(self.boxes, self.scores, self.labels, 0.5, weights=weights)
+        final_boxes, final_scores, final_labels, indices = nms(self.boxes, self.scores, self.labels, 0.5, weights=weights)
 
         # Assertions
         assert final_boxes.shape[0] == 4


### PR DESCRIPTION
**Issue #, if available:** n/a

### Notes
Previously, the NMS function would return lists of normalized bounding boxes, scores, and categories which had to be matched to their input features using a hash of the data values.  In some cases this led to collisions where features were not being mapped correctly.  This change alters the return value of the NMS function to include the indexes of the features  so they can be selected without ambiguity.  This also updates the data types to more consistently leverage np arrays and reduce the number of conversions between them and python Lists.

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
